### PR TITLE
Add new tremor-script recipe, plus some cleanup

### DIFF
--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -15,13 +15,14 @@ A set of terms in common or standardised usage by the tremor project and/or team
 |Binding|A specification of ( set of links ), describing one-or-many interconnections to/from pipelines|
 |Mapping|A configuration of, ( set of bindings ), and set of key/value replacements that describes how to deploy pipelines and how to interconnect binding specifications and map to running instances of tremor artefacts|
 |Repository|An in memory cache that tremor uses to store artefacts. Like a git repository for artefacts|
-|Registry|An in memory cache taht tremor uses to store running onramps, offramps and pipelines. Like the DNS registry for running code that can send, receive or process events|
+|Registry|An in memory cache that tremor uses to store running onramps, offramps and pipelines. Like the DNS registry for running code that can send, receive or process events|
 |Publish|The act of publishing an artefact or deploying a running instance|
 |Find|The act of finding an artefact or running instance by id|
 |Bind|The act of deploying artefacts and making them runnable|
 |Publish-Find-Bind|An Enterprise Integration Pattern common in Registry/Repository services for Application Server Platforms|
 |Deploy|The act of publishing a tremor mapping, the side-effect of which MAY be the deployment of onramps, offramps and/or pipelines|
 |Undeploy|The act of unpublishing a tremor mapping, the side-effect of which MAY be the undeployment of onramps, offramps and/or pipelines|
+|Meta Variables|Global event metadata variables (prefixed with `$` in tremor-script), accessible across pipeline nodes as well as offramps |
 |WAL, Write-ahead Log|An in-memory or persistent data log used by the guaranteed delivery mechanism|
 |CB, Circuit-breaker|A mechanism that can react to failure in sources and sinks in a robust and recoverable way|
 |GD, Guaranteed delivery|A mechanism that guarantees that events that reach a pipeline are processed to completion. Depending on the source/sink this may extend end-to-end|

--- a/docs/development/quick-start.md
+++ b/docs/development/quick-start.md
@@ -84,13 +84,13 @@ Technically, the rust [openssl](https://docs.rs/openssl) crate will try to disco
 
 ### Running Tremor
 
-After installing rust and cloning the repository, you can start tremor server by changing to `tremor` directory in tremor and running:
+After installing rust and cloning the repository, you can start tremor server by running the following from the root (`tremor-runtime`) directory:
 
 ```bash
-cargo run
+cargo run -p tremor-cli -- server run
 ```
 
-To run the test suite, in the root (`tremor-runtime`) directory you can run:
+And to run the test suite, you can run:
 
 ```bash
 cargo test

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,9 +28,10 @@ Other interesting topics are:
     * [Configuration](operations/configuration.md) and the [Configuration Walkthrough](operations/configuration-walkthrough.md)
     * [The tremor CLI](operations/cli.md)
 * [The tremor API](api.md)
+* [Workshop](https://github.com/tremor-rs/tremor-www-docs/tree/main/docs/workshop/) and various use case [examples](https://github.com/tremor-rs/tremor-www-docs/tree/main/docs/workshop/examples)
 * Development related information
     * [Benchmarks](development/benchmarking.md)
     * [A Quickstart Guide](development/quick-start.md)
     * Nots about [Testing](development/testing.md) and [Debugging](development/debugging.md)
 
-This is not an exhaustive list and for the curious it might be worth to explore the `docs` folder on their own.
+This is not an exhaustive list and for the curious it might be worth to explore the [docs](https://github.com/tremor-rs/tremor-www-docs/tree/main/docs) folder on their own.

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -54,7 +54,7 @@ When using the tremor docker image configuration is loaded from the folder `/etc
 The following files are looked for:
 
 - `/etc/tremor/logger.yaml` a [log4rs](https://docs.rs/log4rs/*/log4rs/) configuration file to control logging in tremor.
-- `/etc/tremor/config/*.trickle` all files will be loaded as trickle pipelines - trickle pipelines are always loaded before yaml configuration! The file name in this case (the part before `.trickle`) is the pipeline id which you can use in places like the binding configuration.
+- `/etc/tremor/config/*.trickle` all files will be loaded as trickle pipelines - trickle pipelines are always loaded before yaml configuration! The file name in this case (the part before `.trickle`) is the pipeline id which you can use in places like the binding configuration. The `#!config id = "name"` preprocessor directive can be used to overwrite the naming.
 - `/etc/tremor/config/*.yaml` all files will be loaded as configuration files and evaluated in order (so mappings cannot refer to artefacts in later files!) - NOTE: defining pipelines in yaml is deprecated and trickle pipelines should be used.
 
 ## Static or Bootstrap deployments

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -53,9 +53,9 @@ When using the tremor docker image configuration is loaded from the folder `/etc
 
 The following files are looked for:
 
-- `/etc/tremor/logger.yaml` a [log4rs](https://docs.rs/log4rs/0.8.3/log4rs/) configuration file to control logging in tremor.
-- `/etc/tremor/config/*.trickle` all files will be loaded as trickle pipelines - trickle pipelines are always loaded before yaml configuration!
-- `/etc/tremor/config/*.yaml` all files will be laoded as configuration files and evaluated in order (so mappings can not refer to artifacts in later files!) - NOTE: defining pipelines in yaml is depricated and trickle pipelines should be used.
+- `/etc/tremor/logger.yaml` a [log4rs](https://docs.rs/log4rs/*/log4rs/) configuration file to control logging in tremor.
+- `/etc/tremor/config/*.trickle` all files will be loaded as trickle pipelines - trickle pipelines are always loaded before yaml configuration! The file name in this case (the part before `.trickle`) is the pipeline id which you can use in places like the binding configuration.
+- `/etc/tremor/config/*.yaml` all files will be loaded as configuration files and evaluated in order (so mappings cannot refer to artefacts in later files!) - NOTE: defining pipelines in yaml is deprecated and trickle pipelines should be used.
 
 ## Static or Bootstrap deployments
 

--- a/docs/tremor-script/extractors/glob.md
+++ b/docs/tremor-script/extractors/glob.md
@@ -1,6 +1,6 @@
 # Glob
 
-Glob is an extractor that checks if the input string matches the specified Unix shell-style pattern. The extractor fails if an pattern is specified that is not valid or the string doesn't match the pattern.
+Glob is an extractor that checks if the input string matches the specified [Unix shell-style pattern](https://en.wikipedia.org/wiki/Glob_(programming)#Unix-like). The extractor fails if an pattern is specified that is not valid or the string doesn't match the pattern.
 
 ## Predicate
 

--- a/docs/tremor-script/recipes.md
+++ b/docs/tremor-script/recipes.md
@@ -172,3 +172,29 @@ match event of
   default => null                                         # drop 0% of other events
 end
 ```
+
+## Check if a variable is present/absent
+
+To check if a variable is present, we can rely on the `present` keyword (and inversely, `absent`).
+
+```tremor
+# matches default case
+match present non_existent_var of
+  case true => "is present"
+  default => "not present"
+end;
+```
+
+Note that this is different from the case where a variable is set to `null`, for which we can do [function-based](tremor-script/stdlib/std/type/#is_nullvalue) checks as well as pattern-match with [match](tremor-script/#match).
+
+Using non-existent variables in contexts other than `present` or `absent` will throw an error terminating the script, so this is useful for guarding against that when needed. This is especially useful when working with meta variables as part of tremor runtime, where -- as part of a pipeline node -- we may need to check if a certain meta variable is set or not (eg: from a previous pipeline node) and act accordingly. For such needs, the approach above can be used. Alternatively, we can also rely on [record patterns](tremor-script/#matching-record-patterns) there:
+
+```tremor
+# tests for presence of $key
+match $ of
+  case %{present key} => "present"
+  default => "not present"
+end;
+```
+
+Since `$` gives a record with all the meta variable name-value mapping, this works nicely.

--- a/docs/workshop/README.md
+++ b/docs/workshop/README.md
@@ -20,7 +20,7 @@ tremor-based solutions.
 
 Make sure your environment is setup for building tremor:
 
-[Tremor Quick Start](https://github.com/tremor-rs/tremor-runtime/blob/main/docs/development/quick-start.md)
+[Tremor Quick Start](https://docs.tremor.rs/development/quick-start/)
 
 ### Setup support for your IDE
 


### PR DESCRIPTION
* Add recipe for checking variable presence in tremor-script
* Document trickle filename to pipeline id behavior
* Add meta variables to the glossary
* Improve dev docs and workshop discovery 
* Cleanup some typos and links 