### PR TITLE
Improve LT websocket workshops and document newrelic offramp

### DIFF
--- a/docs/artefacts/offramps.md
+++ b/docs/artefacts/offramps.md
@@ -469,3 +469,27 @@ offramp:
   - id: terminate
     type: exit
 ```
+
+### newrelic
+
+Send events to [New Relic](https://newrelic.com/) platform, using it's log apis (variable by region).
+
+The default [codec](codecs.md#json) is `json`.
+
+Supported configuration options are:
+
+- `license_key` - New Relic's license (or insert only) key
+- `compress_logs` - Whther logs should be compressed before sending to New Relic  (avoids extra egress costs but at the cost of more cpu usage by tremor) (default: false)
+- `region` - Region to use to send logs. Available choices: usa, europe (default: usa)
+
+Example:
+
+```yaml
+offramp:
+  - id: newrelic
+    type: newrelic
+    config:
+      license_key: keystring
+      compress_logs: true
+      region: europe
+```

--- a/docs/workshop/examples/00_passthrough/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/00_passthrough/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/01_filter/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/01_filter/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/02_transform/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/02_transform/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/03_validate/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/03_validate/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/10_logstash/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/10_logstash/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/11_influx/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/11_influx/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/12_postgres_timescaledb/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/12_postgres_timescaledb/etc/tremor/logger.yaml
@@ -15,14 +15,16 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: trace
+  level: info
   appenders:
+    - file
     - stdout
 
 loggers:
   # Write info level logs to the log file
   tremor_runtime:
-    level: trace
+    level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/20_transient_gd/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/20_transient_gd/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/21_persistent_gd/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/21_persistent_gd/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/22_roundrobin/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/22_roundrobin/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/30_servers_lt_http/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/30_servers_lt_http/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/31_servers_lt_ws/README.md
+++ b/docs/workshop/examples/31_servers_lt_ws/README.md
@@ -27,13 +27,12 @@ We configure a websocket onramp listening on port 8139:
 
 Incoming websocket messages from a client's websocket connection are sent to the pipeline `echo` and the output of it is sent back again from the same connection.
 
-```
+```yaml
 binding:
   - id: main
     links:
       "/onramp/ws/{instance}/out": ["/pipeline/echo/{instance}/in"]
       "/pipeline/echo/{instance}/out": ["/onramp/ws/{instance}/in"]
-      "/pipeline/echo/{instance}/err": ["/offramp/system::stderr/system/in"]
 ```
 
 ### Processing logic
@@ -85,4 +84,12 @@ snot
 badger
 goodbye
 goodbye
+```
+
+If there's internal tremor error while processing the incoming message (eg: codec or preprocessor failure), the error should be bubbled up to the client. To test this out, change the codec in the [onramp configuration](etc/tremor/config/config.yaml) to be `json` from `string` and send an invalid json input:
+
+```sh
+# after changing the onramp codec to json
+$ echo "{" | websocat -n1 ws://localhost:8139
+{"error":"[Codec] Syntax at character 0 ('{')","event_id":1,"source_id":"tremor://localhost/onramp/ws/01/in"}
 ```

--- a/docs/workshop/examples/31_servers_lt_ws/etc/tremor/config/config.yaml
+++ b/docs/workshop/examples/31_servers_lt_ws/etc/tremor/config/config.yaml
@@ -14,8 +14,16 @@ binding:
     links:
       "/onramp/ws/{instance}/out": ["/pipeline/echo/{instance}/in"]
       "/pipeline/echo/{instance}/out": ["/onramp/ws/{instance}/in"]
-      "/pipeline/echo/{instance}/err": ["/offramp/system::stderr/system/in"]
+
+  - id: error
+    links:
+      # send back errors as reply as well
+      "/onramp/ws/{instance}/err": ["/pipeline/system::passthrough/system/in"]
+      "/pipeline/echo/{instance}/err": ["/pipeline/system::passthrough/system/in"]
+      "/pipeline/system::passthrough/system/out": ["/onramp/ws/{instance}/in"]
 
 mapping:
   /binding/main/01:
+    instance: "01"
+  /binding/error/01:
     instance: "01"

--- a/docs/workshop/examples/31_servers_lt_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/31_servers_lt_ws/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/32_proxies_lt_http/README.md
+++ b/docs/workshop/examples/32_proxies_lt_http/README.md
@@ -34,7 +34,7 @@ offramp:
 
 Incoming requests from clients are forwarded to the `request_processing` pipeline, from where it goes to the upstream server. The resulting response is then returned back to the client which initiated the request (after any needed processing from the `response_processing` pipeline).
 
-```
+```yaml
 binding:
   - id: main
     links:

--- a/docs/workshop/examples/32_proxies_lt_http/etc/tremor/config/config.yaml
+++ b/docs/workshop/examples/32_proxies_lt_http/etc/tremor/config/config.yaml
@@ -51,12 +51,10 @@ binding:
       # send back errors as response as well
       "/pipeline/internal_error_processing/{instance}/out":
         ["/onramp/http/{instance}/in"]
-        #"/offramp/system::stderr/system/in"
 
       # respond on errors during error processing too
       "/pipeline/internal_error_processing/{instance}/err":
         ["/onramp/http/{instance}/in"]
-        #"/offramp/system::stderr/system/in"
 
 mapping:
   /binding/main/01:

--- a/docs/workshop/examples/32_proxies_lt_http/etc/tremor/config/internal_error_processing.trickle
+++ b/docs/workshop/examples/32_proxies_lt_http/etc/tremor/config/internal_error_processing.trickle
@@ -7,6 +7,8 @@ script
       {"status": 500}
   end;
 
+  let $response.headers["content-type"] = "application/json";
+
   # can choose to not include the actual event error here, if we don't want
   # to send it back to the client
   let event.error = "Oh no, we ran into something unexpected :(\n {event.error}";

--- a/docs/workshop/examples/32_proxies_lt_http/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/32_proxies_lt_http/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/config/config.yaml
+++ b/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/config/config.yaml
@@ -22,7 +22,8 @@ offramp:
 binding:
   - id: main
     links:
-      "/onramp/ws/{instance}/out": ["/pipeline/pass_incoming/{instance}/in"]
+      "/onramp/ws/{instance}/out":
+        ["/pipeline/pass_incoming/{instance}/in"]
 
       "/pipeline/pass_incoming/{instance}/out":
         ["/offramp/upstream/{instance}/in"]
@@ -33,6 +34,20 @@ binding:
       "/pipeline/pass_outgoing/{instance}/out":
         ["/onramp/ws/{instance}/in"]
 
+  - id: error
+    links:
+      "/onramp/ws/{instance}/err":
+        ["/pipeline/pass_errors/{instance}/in"]
+
+      "/offramp/upstream/{instance}/err":
+        ["/pipeline/pass_errors/{instance}/in"]
+
+      # send back errors as reply as well
+      "/pipeline/pass_errors/{instance}/out":
+        ["/onramp/ws/{instance}/in"]
+
 mapping:
   /binding/main/01:
+    instance: "01"
+  /binding/error/01:
     instance: "01"

--- a/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/config/pass_errors.trickle
+++ b/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/config/pass_errors.trickle
@@ -1,0 +1,1 @@
+select event from in into out;

--- a/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/config/config.yaml
+++ b/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/config/config.yaml
@@ -57,10 +57,8 @@ binding:
         ["/onramp/http/{instance}/in"]
 
       # respond on errors during error processing too
-      "/pipeline/internal_error_processing/{instance}/err": [
-        "/onramp/http/{instance}/in",
-        "/offramp/system::stderr/system/in"
-      ]
+      "/pipeline/internal_error_processing/{instance}/err":
+        ["/onramp/http/{instance}/in", "/offramp/system::stderr/system/in"]
 
 mapping:
   /binding/main/01:

--- a/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/config/config.yaml
+++ b/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/config/config.yaml
@@ -55,12 +55,12 @@ binding:
       # send back errors as response as well
       "/pipeline/internal_error_processing/{instance}/out":
         ["/onramp/http/{instance}/in"]
-        #"/offramp/system::stderr/system/in"
 
       # respond on errors during error processing too
-      "/pipeline/internal_error_processing/{instance}/err":
-        ["/onramp/http/{instance}/in"]
-        #"/offramp/system::stderr/system/in"
+      "/pipeline/internal_error_processing/{instance}/err": [
+        "/onramp/http/{instance}/in",
+        "/offramp/system::stderr/system/in"
+      ]
 
 mapping:
   /binding/main/01:

--- a/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/config/internal_error_processing.trickle
+++ b/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/config/internal_error_processing.trickle
@@ -7,6 +7,8 @@ script
       {"status": 500}
   end;
 
+  let $response.headers["content-type"] = "application/json";
+
   # can choose to not include the actual event error here, if we don't want
   # to send it back to the client
   let event.error = "Oh no, we ran into something unexpected :(\n {event.error}";

--- a/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/logger.yaml
@@ -17,6 +17,7 @@ appenders:
 root:
   level: info
   appenders:
+    - file
     - stdout
 
 loggers:
@@ -25,4 +26,5 @@ loggers:
     level: info
     appenders:
       - file
+      - stdout
     additive: false

--- a/docs/workshop/examples/35_reverse_proxy_load_balancing/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/35_reverse_proxy_load_balancing/etc/tremor/logger.yaml
@@ -6,9 +6,25 @@ appenders:
   stdout:
     kind: console
 
+  # An appender named "requests" that writes to a file with a custom pattern encoder
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 # Write only warnings to stdout
 root:
-  level: debug
+  level: info
   appenders:
+    - file
     - stdout
 
+loggers:
+  # Write info level logs to the log file
+  tremor_runtime:
+    level: info
+    appenders:
+      - file
+      - stdout
+    additive: false


### PR DESCRIPTION
Include proper error handling for LT websocket workshops.

Also document newrelic offramp, initially added via https://github.com/tremor-rs/tremor-runtime/pull/357 