### PR TITLE
Only log to stdout for all workshop examples.

### DIFF
--- a/docs/workshop/examples/00_passthrough/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/00_passthrough/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/00_passthrough/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/00_passthrough/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/00_passthrough/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/00_passthrough/etc/tremor/logger.yaml
@@ -5,21 +5,29 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/01_filter/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/01_filter/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/01_filter/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/01_filter/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/01_filter/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/01_filter/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/02_transform/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/02_transform/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/02_transform/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/02_transform/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/02_transform/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/02_transform/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/03_validate/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/03_validate/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/03_validate/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/03_validate/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/03_validate/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/03_validate/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/10_logstash/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/10_logstash/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/10_logstash/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/10_logstash/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/10_logstash/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/10_logstash/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/11_influx/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/11_influx/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/11_influx/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/11_influx/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/11_influx/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/11_influx/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/12_postgres_timescaledb/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/12_postgres_timescaledb/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/12_postgres_timescaledb/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/12_postgres_timescaledb/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/12_postgres_timescaledb/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/12_postgres_timescaledb/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/20_transient_gd/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/20_transient_gd/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/20_transient_gd/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/20_transient_gd/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/20_transient_gd/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/20_transient_gd/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/21_persistent_gd/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/21_persistent_gd/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/21_persistent_gd/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/21_persistent_gd/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/21_persistent_gd/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/21_persistent_gd/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/22_roundrobin/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/22_roundrobin/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/22_roundrobin/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/22_roundrobin/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/22_roundrobin/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/22_roundrobin/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/23_kafka_gd/docker-compose.yaml
+++ b/docs/workshop/examples/23_kafka_gd/docker-compose.yaml
@@ -37,5 +37,5 @@ services:
       - RUST_LOG=info
     volumes:
       - ./etc/tremor_out:/etc/tremor:ro
-      - ./logs:/logs:rw
+      - ./var/log:/var/log:rw
       - ./data:/data:ro

--- a/docs/workshop/examples/23_kafka_gd/etc/tremor_in/logger.yaml
+++ b/docs/workshop/examples/23_kafka_gd/etc/tremor_in/logger.yaml
@@ -6,23 +6,19 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
-# Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
 
 loggers:
-  # Write info level logs to the log file
   tremor_runtime:
     level: info
     appenders:
-      - file
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
     additive: false

--- a/docs/workshop/examples/23_kafka_gd/etc/tremor_in/logger.yaml
+++ b/docs/workshop/examples/23_kafka_gd/etc/tremor_in/logger.yaml
@@ -5,20 +5,29 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor_in.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/23_kafka_gd/etc/tremor_out/logger.yaml
+++ b/docs/workshop/examples/23_kafka_gd/etc/tremor_out/logger.yaml
@@ -6,23 +6,19 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
-# Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
 
 loggers:
-  # Write info level logs to the log file
   tremor_runtime:
     level: info
     appenders:
-      - file
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
     additive: false

--- a/docs/workshop/examples/23_kafka_gd/etc/tremor_out/logger.yaml
+++ b/docs/workshop/examples/23_kafka_gd/etc/tremor_out/logger.yaml
@@ -5,20 +5,29 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor_out.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/30_servers_lt_http/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/30_servers_lt_http/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/30_servers_lt_http/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/30_servers_lt_http/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/30_servers_lt_http/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/30_servers_lt_http/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/31_servers_lt_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/31_servers_lt_ws/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/31_servers_lt_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/31_servers_lt_ws/etc/tremor/logger.yaml
@@ -4,22 +4,31 @@ refresh_rate: 30 seconds
 appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
-    kind: console
+      kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/31_servers_lt_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/31_servers_lt_ws/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/32_proxies_lt_http/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/32_proxies_lt_http/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/32_proxies_lt_http/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/32_proxies_lt_http/etc/tremor/logger.yaml
@@ -4,22 +4,31 @@ refresh_rate: 30 seconds
 appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
-    kind: console
+      kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/32_proxies_lt_http/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/32_proxies_lt_http/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/33_proxies_lt_ws/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/logger.yaml
@@ -5,21 +5,30 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false

--- a/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/34_bridges_lt_http_ws/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/35_reverse_proxy_load_balancing/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/35_reverse_proxy_load_balancing/etc/tremor/logger.yaml
@@ -6,25 +6,8 @@ appenders:
   stdout:
     kind: console
 
-  # An appender named "requests" that writes to a file with a custom pattern encoder
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} - {m}{n}"
-
 # Write only warnings to stdout
 root:
   level: info
   appenders:
-    - file
     - stdout
-
-loggers:
-  # Write info level logs to the log file
-  tremor_runtime:
-    level: info
-    appenders:
-      - file
-      - stdout
-    additive: false

--- a/docs/workshop/examples/35_reverse_proxy_load_balancing/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/35_reverse_proxy_load_balancing/etc/tremor/logger.yaml
@@ -5,21 +5,29 @@ appenders:
   # An appender named "stdout" that writes to stdout
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 # Write only warnings to stdout
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
-      - stdout
+        - stdout
     additive: false

--- a/docs/workshop/examples/35_reverse_proxy_load_balancing/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/35_reverse_proxy_load_balancing/etc/tremor/logger.yaml
@@ -8,6 +8,18 @@ appenders:
 
 # Write only warnings to stdout
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false

--- a/docs/workshop/examples/36_quota_service/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/36_quota_service/etc/tremor/logger.yaml
@@ -4,29 +4,38 @@ refresh_rate: 30 seconds
 appenders:
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 
 root:
   level: warn
   appenders:
     - stdout
+    - file
 
 loggers:
   tremor_runtime:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   tremor:
     level: info
     appenders:
       - stdout
+      - file
     additive: false
   # FIXME resolve these repeated info logs. can then eliminate this override
   #Elastic search error: Err(Error(ElasticError(Client(ClientError { inner: Error(Response(400), State { next_error: Some(Parse(ParseError { inner: UnknownApiError({"reason": String("request body is required"), "root_cause": Array([Object({"reason": String("request body is required"), "type": String("parse_exception")})]), "type": String("parse_exception")}) })), backtrace: None }) })), State { next_error: None, backtrace: InternalBacktrace { backtrace: None } }))
   tremor_runtime::sink::elastic:
     level: warn
     appenders:
-      #- stdout
+      - stdout
       - file
     additive: false

--- a/docs/workshop/examples/36_quota_service/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/36_quota_service/etc/tremor/logger.yaml
@@ -5,29 +5,23 @@ appenders:
   stdout:
     kind: console
 
-  # FIXME eliminate this after resolving logging overrides below
-  # (using this to route away noisy logs from stdout for now)
-  file:
-    kind: file
-    path: "/var/log/tremor/tremor.log"
-    encoder:
-      pattern: "{d} {l} {M} - {m}{n}"
 
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
 
 loggers:
-  # FIXME resolve these repeated info logs. can then eliminate this override
-  # INFO elastic::http::sender::synchronous - Elasticsearch Response: correlation_id: '785298c7-622a-4c7b-96ba-e0109a944921', status: '400 Bad Request'
-  elastic::http::sender::synchronous:
-    level: warn
+  tremor_runtime:
+    level: info
     appenders:
-      #- stdout
-      - file
+      - stdout
     additive: false
-
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false
   # FIXME resolve these repeated info logs. can then eliminate this override
   #Elastic search error: Err(Error(ElasticError(Client(ClientError { inner: Error(Response(400), State { next_error: Some(Parse(ParseError { inner: UnknownApiError({"reason": String("request body is required"), "root_cause": Array([Object({"reason": String("request body is required"), "type": String("parse_exception")})]), "type": String("parse_exception")}) })), backtrace: None }) })), State { next_error: None, backtrace: InternalBacktrace { backtrace: None } }))
   tremor_runtime::sink::elastic:

--- a/docs/workshop/examples/37_configurator/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/37_configurator/etc/tremor/logger.yaml
@@ -4,6 +4,12 @@ refresh_rate: 30 seconds
 appenders:
   stdout:
     kind: console
+  file:
+    kind: file
+    path: "/var/log/tremor/tremor.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+
 
 root:
   level: warn

--- a/docs/workshop/examples/37_configurator/etc/tremor/logger.yaml
+++ b/docs/workshop/examples/37_configurator/etc/tremor/logger.yaml
@@ -6,6 +6,20 @@ appenders:
     kind: console
 
 root:
-  level: info
+  level: warn
   appenders:
     - stdout
+
+loggers:
+  tremor_runtime:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+  tremor:
+    level: info
+    appenders:
+      - stdout
+    additive: false
+
+


### PR DESCRIPTION
Otherwise insightful log messages from tremor might get lost, leaving users clueless.

@anupdhml this might put some more log messages into the users face. i think we can tweak on a case per case basis if needed. What do you think?