### PR TITLE
Update repository to ghcr

### DIFF
--- a/docs/course/testing/assets/check-setup.yml
+++ b/docs/course/testing/assets/check-setup.yml
@@ -1,50 +1,49 @@
 # The configurations that used for the recording, feel free to edit them
 config:
-
   # Specify a command to be executed
   # like `/bin/bash -l`, `ls`, or any other commands
   # the default is bash for Linux
   # or powershell.exe for Windows
   command: /bin/zsh
-  
+
   # Specify the current working directory path
   # the default is the current working directory path
   cwd: /Users/dennis/Code/oss/tremor-rs/tremor-www-docs/docs/course/testing
-  
+
   # Export additional ENV variables
   env:
     recording: true
-  
+
   # Explicitly set the number of columns
   # or use `auto` to take the current
   # number of columns of your shell
   cols: 78
-  
+
   # Explicitly set the number of rows
   # or use `auto` to take the current
   # number of rows of your shell
   rows: 20
-  
+
   # Amount of times to repeat GIF
   # If value is -1, play once
   # If value is 0, loop indefinitely
   # If value is a positive number, loop n times
   repeat: 0
-  
+
   # Quality
   # 1 - 100
   quality: 100
-  
+
   # Delay between frames in ms
   # If the value is `auto` use the actual recording delays
   # frameDelay: auto
   frameDelay: 200
-  
+
   # Maximum delay between frames in ms
   # Ignored if the `frameDelay` isn't set to `auto`
   # Set to `auto` to prevent limiting the max idle time
   maxIdleTime: 2000
-  
+
   # The surrounding frame box
   # The `type` can be null, window, floating, or solid`
   # To hide the title use the value null
@@ -56,7 +55,7 @@ config:
       border: 0px black solid
       # boxShadow: none
       # margin: 0px
-  
+
   # Add a watermark image to the rendered gif
   # You need to specify an absolute path for
   # the image on your machine or a URL, and you can also
@@ -69,25 +68,25 @@ config:
       bottom: 15px
       width: 100px
       opacity: 0.9
-  
+
   # Cursor style can be one of
   # `block`, `underline`, or `bar`
   cursorStyle: block
-  
+
   # Font family
   # You can use any font that is installed on your machine
   # in CSS-like syntax
   fontFamily: "Monaco, Lucida Console, Ubuntu Mono, Monospace"
-  
+
   # The size of the font
   fontSize: 12
-  
+
   # The height of lines
   lineHeight: 1
-  
+
   # The spacing between letters
   letterSpacing: 0
-  
+
   # Theme
   theme:
     background: "transparent"
@@ -109,7 +108,7 @@ config:
     brightMagenta: "#ae89fe"
     brightCyan: "#b1c6ca"
     brightWhite: "#f9f9f4"
-  
+
 # Records, feel free to edit them
 records:
   - delay: 1874
@@ -129,7 +128,7 @@ records:
   - delay: 150
     content: t
   - delay: 105
-    content: ' '
+    content: " "
   - delay: 269
     content: T
   - delay: 256
@@ -155,7 +154,7 @@ records:
   - delay: 91
     content: E
   - delay: 283
-    content: '='
+    content: "="
   - delay: 120
     content: t
   - delay: 165
@@ -197,7 +196,7 @@ records:
   - delay: 120
     content: r
   - delay: 285
-    content: ':'
+    content: ":"
   - delay: 255
     content: l
   - delay: 165
@@ -211,7 +210,7 @@ records:
   - delay: 61
     content: t
   - delay: 660
-    content: "\e[?1l\e>\e[?2004l\r\r\n\e]2;export TREMOR_IMAGE=tremorproject/tremor:latest \a\e]1;export\a\e[1m\e[7m%\e[27m\e[1m\e[0m                                                                             \r \r\e]2;dennis@ALT01827: ~/Code/oss/tremor-rs/tremor-www-docs/docs/course/testing\a\e]1;..ourse/testing\a"
+    content: "\e[?1l\e>\e[?2004l\r\r\n\e]2;export TREMOR_IMAGE=docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest \a\e]1;export\a\e[1m\e[7m%\e[27m\e[1m\e[0m                                                                             \r \r\e]2;dennis@ALT01827: ~/Code/oss/tremor-rs/tremor-www-docs/docs/course/testing\a\e]1;..ourse/testing\a"
   - delay: 77
     content: "\r\e[0m\e[27m\e[24m\e[J\e[01;32m➜  \e[36mtesting\e[00m \e[01;34mgit:(\e[31mmain\e[34m) \e[33m✗\e[00m \e[K\e[?1h\e=\e[?2004h"
   - delay: 1782
@@ -227,7 +226,7 @@ records:
   - delay: 45
     content: r
   - delay: 89
-    content: ' '
+    content: " "
   - delay: 136
     content: p
   - delay: 105
@@ -237,7 +236,7 @@ records:
   - delay: 180
     content: l
   - delay: 104
-    content: ' '
+    content: " "
   - delay: 196
     content: $
   - delay: 286
@@ -267,7 +266,7 @@ records:
   - delay: 496
     content: "\e[?1l\e>\e[?2004l\r\r\n\e]2;docker pull $TREMOR_IMAGE\a\e]1;docker\a"
   - delay: 1862
-    content: "latest: Pulling from tremorproject/tremor\r\nDigest: sha256:7a5d0db28d60eb51783d1c35f28827fd84bc8c767cb7296c4cf68c1aa064d0e4\r\nStatus: Image is up to date for tremorproject/tremor:latest\r\ndocker.io/tremorproject/tremor:latest\r\n"
+    content: "latest: Pulling from tremorproject/tremor\r\nDigest: sha256:7a5d0db28d60eb51783d1c35f28827fd84bc8c767cb7296c4cf68c1aa064d0e4\r\nStatus: Image is up to date for docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest\r\ndocker.io/docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest\r\n"
   - delay: 5
     content: "\e[1m\e[7m%\e[27m\e[1m\e[0m                                                                             \r \r\e]2;dennis@ALT01827: ~/Code/oss/tremor-rs/tremor-www-docs/docs/course/testing\a\e]1;..ourse/testing\a"
   - delay: 67
@@ -283,7 +282,7 @@ records:
   - delay: 46
     content: s
   - delay: 120
-    content: ' '
+    content: " "
   - delay: 150
     content: t
   - delay: 150
@@ -299,9 +298,9 @@ records:
   - delay: 90
     content: r
   - delay: 570
-    content: '='
+    content: "="
   - delay: 570
-    content: ''''
+    content: "'"
   - delay: 570
     content: d
   - delay: 75
@@ -315,29 +314,29 @@ records:
   - delay: 75
     content: r
   - delay: 105
-    content: ' '
+    content: " "
   - delay: 105
     content: r
   - delay: 89
     content: u
   - delay: 226
-    content: 'n'
+    content: "n"
   - delay: 104
-    content: ' '
+    content: " "
   - delay: 166
-    content: '-'
+    content: "-"
   - delay: 255
     content: i
   - delay: 105
-    content: ' '
+    content: " "
   - delay: 134
-    content: '-'
+    content: "-"
   - delay: 136
     content: v
   - delay: 119
-    content: ' '
+    content: " "
   - delay: 1111
-    content: '`'
+    content: "`"
   - delay: 256
     content: p
   - delay: 44
@@ -345,9 +344,9 @@ records:
   - delay: 90
     content: d
   - delay: 389
-    content: '`'
+    content: "`"
   - delay: 450
-    content: ':'
+    content: ":"
   - delay: 885
     content: /
   - delay: 481
@@ -357,7 +356,7 @@ records:
   - delay: 74
     content: d
   - delay: 2025
-    content: ' '
+    content: " "
   - delay: 286
     content: $
   - delay: 299
@@ -385,13 +384,13 @@ records:
   - delay: 541
     content: "\rGE"
   - delay: 1184
-    content: ' '
+    content: " "
   - delay: 301
     content: $
   - delay: 149
-    content: '*'
+    content: "*"
   - delay: 1815
-    content: ''''
+    content: "'"
   - delay: 331
     content: "\e[?1l\e>\e[?2004l\r\r\n\e]2;alias trecker='docker run -i -v `pwd`:/pwd $TREMOR_IMAGE $*'\a\e]1;alias\a\e[1m\e[7m%\e[27m\e[1m\e[0m                                                                             \r \r\e]2;dennis@ALT01827: ~/Code/oss/tremor-rs/tremor-www-docs/docs/course/testing\a\e]1;..ourse/testing\a"
   - delay: 71
@@ -411,9 +410,9 @@ records:
   - delay: 74
     content: r
   - delay: 60
-    content: ' '
+    content: " "
   - delay: 120
-    content: '-'
+    content: "-"
   - delay: 210
     content: h
   - delay: 421

--- a/docs/course/testing/index.txt
+++ b/docs/course/testing/index.txt
@@ -17,7 +17,7 @@ $ tremor test # ... arguments
 This course assumes an installation of [docker](https://www.docker.com)
 
 ```shell [1|2|3|4-5]
-$ export TREMOR_IMAGE=tremorproject/tremor:latest # set to `edge` if you feel lucky
+$ export TREMOR_IMAGE=docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest # set to `edge` if you feel lucky
 $ docker pull $TREMOR_IMAGE
 alias trecker=
   'docker run -i -v `pwd`:/pwd $TREMOR_IMAGE $*'

--- a/docs/workshop/examples/00_passthrough/docker-compose.yaml
+++ b/docs/workshop/examples/00_passthrough/docker-compose.yaml
@@ -1,7 +1,7 @@
-version: '3.3'
+version: "3.3"
 services:
   tremor:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     ports:
       - 4242:4242
     environment:

--- a/docs/workshop/examples/01_filter/docker-compose.yaml
+++ b/docs/workshop/examples/01_filter/docker-compose.yaml
@@ -1,7 +1,7 @@
-version: '3.3'
+version: "3.3"
 services:
   tremor:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     ports:
       - 4242:4242
     environment:

--- a/docs/workshop/examples/02_transform/docker-compose.yaml
+++ b/docs/workshop/examples/02_transform/docker-compose.yaml
@@ -1,7 +1,7 @@
-version: '3.3'
+version: "3.3"
 services:
   tremor:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     ports:
       - 4242:4242
     environment:

--- a/docs/workshop/examples/03_validate/docker-compose.yaml
+++ b/docs/workshop/examples/03_validate/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   tremor:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     ports:
       - 4242:4242
     environment:

--- a/docs/workshop/examples/10_logstash/docker-compose.yaml
+++ b/docs/workshop/examples/10_logstash/docker-compose.yaml
@@ -1,24 +1,24 @@
-version: '3.3'
+version: "3.3"
 services:
   elastic:
-    image: 'docker.elastic.co/elasticsearch/elasticsearch:6.6.1'
+    image: "docker.elastic.co/elasticsearch/elasticsearch:6.6.1"
     ports:
-      - '9200:9200'
-      - '9300:9300'
+      - "9200:9200"
+      - "9300:9300"
     environment:
       discovery.type: single-node
   kibana:
-    image: 'docker.elastic.co/kibana/kibana:6.6.1'
+    image: "docker.elastic.co/kibana/kibana:6.6.1"
     ports:
-      - '5601:5601'
+      - "5601:5601"
     depends_on:
       - elastic
     environment:
-      ELASTICSEARCH_URL: 'http://elastic:9200'
+      ELASTICSEARCH_URL: "http://elastic:9200"
     links:
       - elastic
   tremor:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     depends_on:
       - kibana
     ports:

--- a/docs/workshop/examples/11_influx/docker-compose.yaml
+++ b/docs/workshop/examples/11_influx/docker-compose.yaml
@@ -1,16 +1,16 @@
-version: '3.3'
+version: "3.3"
 services:
   influxdb:
     image: influxdb:1.7
     ports:
-      - '8086:8086'
-      - '8083:8083'
+      - "8086:8086"
+      - "8083:8083"
     environment:
-      INFLUXDB_DB: 'tremor'
+      INFLUXDB_DB: "tremor"
   chronograf:
     image: chronograf:1.7
     ports:
-      - '8888:8888'
+      - "8888:8888"
     depends_on:
       - influxdb
   telegraf:
@@ -21,7 +21,7 @@ services:
     volumes:
       - ./etc/telegraf:/etc/telegraf:ro
   tremor:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     depends_on:
       - influxdb
     ports:

--- a/docs/workshop/examples/12_postgres_timescaledb/docker-compose.yaml
+++ b/docs/workshop/examples/12_postgres_timescaledb/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   tremor:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     depends_on:
       - postgres
       - timescaledb
@@ -35,7 +35,8 @@ services:
       - 9876:5432
     volumes:
       - ./seed_pg.sh:/docker-entrypoint-initdb.d/init.sh
-    command: ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]
+    command:
+      ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]
   timescaledb:
     image: timescale/timescaledb:2.0.0-beta6-pg12
     restart: always
@@ -46,4 +47,5 @@ services:
       - 5432:5432
     volumes:
       - ./seed_tsdb.sh:/docker-entrypoint-initdb.d/init.sh
-    command: ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]
+    command:
+      ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]

--- a/docs/workshop/examples/23_kafka_gd/docker-compose.yaml
+++ b/docs/workshop/examples/23_kafka_gd/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
   tremor_in:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     depends_on:
       - kafka
     environment:
@@ -28,7 +28,7 @@ services:
       - ./logs:/logs:rw
       - ./data:/data:ro
   tremor_out:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     depends_on:
       - kafka
     environment:

--- a/docs/workshop/examples/30_servers_lt_http/docker-compose.yaml
+++ b/docs/workshop/examples/30_servers_lt_http/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   tremor:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     ports:
       - 9898:9898
       - 8139:8139

--- a/docs/workshop/examples/31_servers_lt_ws/docker-compose.yaml
+++ b/docs/workshop/examples/31_servers_lt_ws/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   tremor:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     ports:
       - 9898:9898
       - 8139:8139

--- a/docs/workshop/examples/32_proxies_lt_http/docker-compose.yaml
+++ b/docs/workshop/examples/32_proxies_lt_http/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   tremor-server:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     ports:
       - 9898:9898
       - 8139:8139
@@ -13,7 +13,7 @@ services:
       - ../30_servers_lt_http/etc/tremor:/etc/tremor:rw
       - ../30_servers_lt_http/var/log:/var/log:rw
   tremor-proxy:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     depends_on:
       - tremor-server
     ports:

--- a/docs/workshop/examples/33_proxies_lt_ws/docker-compose.yaml
+++ b/docs/workshop/examples/33_proxies_lt_ws/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   tremor-server:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     ports:
       - 9898:9898
       - 8139:8139
@@ -13,7 +13,7 @@ services:
       - ../31_servers_lt_ws/etc/tremor:/etc/tremor:rw
       - ../31_servers_lt_ws/var/log:/var/log:rw
   tremor-proxy:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     depends_on:
       - tremor-server
     ports:

--- a/docs/workshop/examples/34_bridges_lt_http_ws/docker-compose.yaml
+++ b/docs/workshop/examples/34_bridges_lt_http_ws/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   tremor-server:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     ports:
       - 9898:9898
       - 8139:8139
@@ -13,7 +13,7 @@ services:
       - ../31_servers_lt_ws/etc/tremor:/etc/tremor:rw
       - ../31_servers_lt_ws/var/log:/var/log:rw
   tremor-bridge:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     depends_on:
       - tremor-server
     ports:

--- a/docs/workshop/examples/35_reverse_proxy_load_balancing/docker-compose.yml
+++ b/docs/workshop/examples/35_reverse_proxy_load_balancing/docker-compose.yml
@@ -1,24 +1,24 @@
 version: "3.7"
 
 services:
-    tremor:
-        image: tremorproject/tremor:latest
-        depends_on:
-            - webserver01
-            - webserver02
-            - webserver03
-        environment:
-            - RUST_BACKTRACE=full
-            - RUST_LOG=trace
-        volumes:
-            - ./etc/tremor:/etc/tremor:rw
-            - ./var/log:/var/log:rw
-        ports:
-            - 9898:9898
-            - 65535:65535
-    webserver01:
-        image: kennethreitz/httpbin:latest
-    webserver02:
-        image: kennethreitz/httpbin:latest
-    webserver03:
-        image: kennethreitz/httpbin:latest
+  tremor:
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
+    depends_on:
+      - webserver01
+      - webserver02
+      - webserver03
+    environment:
+      - RUST_BACKTRACE=full
+      - RUST_LOG=trace
+    volumes:
+      - ./etc/tremor:/etc/tremor:rw
+      - ./var/log:/var/log:rw
+    ports:
+      - 9898:9898
+      - 65535:65535
+  webserver01:
+    image: kennethreitz/httpbin:latest
+  webserver02:
+    image: kennethreitz/httpbin:latest
+  webserver03:
+    image: kennethreitz/httpbin:latest

--- a/docs/workshop/examples/37_configurator/docker-compose.yaml
+++ b/docs/workshop/examples/37_configurator/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   configurator_tremor:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     depends_on:
       - quota_service_1
       - quota_service_2
@@ -18,7 +18,7 @@ services:
       - 9139:9139 # the configurator
 
   quota_service_1:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     container_name: quota_service_1
     environment:
       - RUST_BACKTRACE=full
@@ -28,7 +28,7 @@ services:
       - 8139:8139
 
   quota_service_2:
-    image: tremorproject/tremor:latest
+    image: docker.pkg.github.com/tremor-rs/tremor-runtime/tremor:latest
     container_name: quota_service_2
     environment:
       - RUST_BACKTRACE=full


### PR DESCRIPTION
Update docker images to use GHCR instead of dockerhub.

Opened as a draft for now to determine if we want this or not.

PRO:
- Prevents users from running into docker image pull issues (especially w/ anonymous accounts behind a NAT)

CONS:
- people might be more used to the dockerhub urls