### PR TITLE
fix id of binding

### DIFF
--- a/docs/workshop/examples/00_passthrough/README.md
+++ b/docs/workshop/examples/00_passthrough/README.md
@@ -33,9 +33,9 @@ The [binding](./etc/tremor/config/01_binding.yaml) expresses those relations and
 
 ```yaml
 binding:
-  - id: passthrough # The unique name of this binding template
+  - id: example # The unique name of this binding template
     links:
-      "/onramp/ws-input/{instance}/out": # Connect the inpunt to the pipeline
+      "/onramp/ws-input/{instance}/out": # Connect the input to the pipeline
         - "/pipeline/example/{instance}/in"
       "/pipeline/example/{instance}/out": # Connect the pipeline to the output
         - "/offramp/stdout-output/{instance}/in"


### PR DESCRIPTION
Fix binding id in `passthrough` example to reflect that of actual file.