### PR TITLE
Typo fixes in workshop examples

### DIFF
--- a/docs/tremor-query/walkthrough.md
+++ b/docs/tremor-query/walkthrough.md
@@ -180,7 +180,7 @@ Branch data into 3 different output stream ports
 ```tremor
 select event from in into out/a;
 select event from in into out/b;
-select event from in inout out/c;
+select event from in into out/c;
 ```
 
 Branch data into 3 different intermediate streams
@@ -206,7 +206,7 @@ Combine 3 data streams into a single output stream
 
 select event from a into out;
 select event from b into out;
-select event from c inout out;
+select event from c into out;
 ```
 
 Combine 3 data stream ports from 1 or many streams into a single output stream
@@ -216,7 +216,7 @@ Combine 3 data stream ports from 1 or many streams into a single output stream
 
 select event from a/1 into out;
 select event from a/2 into out;
-select event from b inout out;
+select event from b into out;
 ```
 
 ## Aggregations

--- a/docs/workshop/examples/01_filter/README.md
+++ b/docs/workshop/examples/01_filter/README.md
@@ -53,7 +53,7 @@ Events are selected on the inbound event if the `numeric` field on the inbound e
 ```trickle
 select event
 from in
-where event.numeric <= 10 or >= 100
+where event.numeric <= 10 or event.numeric >= 100
 into out
 ```
 
@@ -71,12 +71,12 @@ having event.selected
 #### Where and Having clauses
 
 Events are selected on the inbound event if the `numeric` field on the inbound event is less than or equal to `10` or
-greater than or equal to `100` and after procerssing them the `selected` field on the outbound event is true.
+greater than or equal to `100` and after processing them, the `selected` field on the outbound event is true.
 
 ```trickle
 select event
 from in
-where event.numeric_filed <= 10 or >= 100
+where event.numeric <= 10 or event.numeric >= 100
 into out
 having event.selected
 ```

--- a/docs/workshop/examples/02_transform/README.md
+++ b/docs/workshop/examples/02_transform/README.md
@@ -1,6 +1,6 @@
 # Transform
 
-The `transform` exmaple builds on the [filter example](../01_filter/README.md) and extends the [`example.trickle`](etc/tremor/config/example.trickle) by adding a transformation that modifies the incoming event. The produced event from this query statement has a different structure than the incoming event.
+The `transform` example builds on the [filter example](../01_filter/README.md) and extends the [`example.trickle`](etc/tremor/config/example.trickle) by adding a transformation that modifies the incoming event. The produced event from this query statement has a different structure than the incoming event.
 
 ## Environment
 

--- a/docs/workshop/examples/03_validate/README.md
+++ b/docs/workshop/examples/03_validate/README.md
@@ -1,6 +1,6 @@
 # Transform
 
-The `validate` exmaple adds the concept of scripts to the trickle file. In this script we validate the schema of the input json against some requirements and only let events through that do satisfy them. Other evetns are dropped. Those changes are entirely inside the [`example.trickle`](etc/tremor/config/example.trickle).
+The `validate` example adds the concept of scripts to the trickle file. In this script we validate the schema of the input json against some requirements and only let events through that do satisfy them. Other events are dropped. Those changes are entirely inside the [`example.trickle`](etc/tremor/config/example.trickle).
 
 ## Environment
 
@@ -60,4 +60,4 @@ $ cat invalids.txt | websocat ws://localhost:4242
 We introduce the `declare script` and `create script` query language features. `delcare script` lets declare a template for a script to be run while `create script` instanciates it as a part of the graph. `create script` takes an additional `as <name>` argument if it is omitted the operator will have the same name as the declaration.
 
 !!! tip
-    Scripts themselfs can not connect to elements inside the graph, a `select` statement is needed to glue scripts and other logic together.
+    Scripts themselves can not connect to elements inside the graph, a `select` statement is needed to glue scripts and other logic together.


### PR DESCRIPTION
* fix query in filter workshop
* few typos
* fix query in tremor-query walkthrough