### PR TITLE
Add docs for Kafka message headers

### DIFF
--- a/docs/artefacts/offramps.md
+++ b/docs/artefacts/offramps.md
@@ -359,7 +359,9 @@ Supported configuration options are:
 
 Used metadata variables:
 
-- `$kafka_key` - same as config `key` (optional. overrides related config param when present)
+- `$kafka` - Record consisting of the following meta information:
+    - `$headers`: A record denoting the [headers](https://kafka.apache.org/20/javadoc/index.html?org/apache/kafka/connect/header/Header.html) for the message.
+    - `$key`: Same as config `key` (optional. overrides related config param when present)
 
 Example:
 

--- a/docs/artefacts/onramps.md
+++ b/docs/artefacts/onramps.md
@@ -78,6 +78,12 @@ Supported configuration options are:
 - `interval` - The interval in which events are sent in nanoseconds.
 - `iters` - Number of times the file will be repeated.
 
+Set metadata variables are:
+
+- `$kafka` - Record consisting of two optional keys:
+    - `$headers`: A record denoting the [headers](https://kafka.apache.org/20/javadoc/index.html?org/apache/kafka/connect/header/Header.html) for the message (if any).
+    - `$key`: The key used for this message in bytes (if any).
+
 Example:
 
 ```yaml


### PR DESCRIPTION
Documentation related to https://github.com/tremor-rs/tremor-runtime/pull/766, integrating Kafka message headers available as the `$kafka_headers` metadata variable.

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>