### PR TITLE
Update kafka docs for new config values and autocommit behaviour

### DIFF
--- a/docs/artefacts/offramps.md
+++ b/docs/artefacts/offramps.md
@@ -38,6 +38,7 @@ The column `Disconnect events` describes under which circumstances this offramp 
 | Offramp   | Disconnect events | Delivery acknowledgements |
 | --------- | ----------------- | ------------------------- |
 | blackhole | never             | always                    |
+| cb        | never             | always                    |
 | debug     | never             | always                    |
 | elastic   | connection loss   | on 200 replies            |
 | exit      | never             | always                    |
@@ -87,6 +88,45 @@ offramp:
       warmup_secs: 10
       stop_after_secs: 40
 ```
+
+### cb
+
+`cb` is short for circuit breaker. This offramp can be used to trigger certain circuit breaker events manually by sending the intended circuit breaker event in the event metadata or the event data.
+Supported payloads are:
+
+ - `ack`
+ - `fail`
+ - `trigger` or `close`
+ - `open` or `restore`
+
+ No matter how many `ack` and `fail` strings the `cb` key contains, only ever one `ack` or `fail` CB event will be emitted, to stay within the CB protocol.
+ The same is true for `trigger`/`close` and `open`/`restore` strings, only one of those two will be emitted, never more.
+
+ Example config:
+
+```yaml
+ offramp:
+   - id: cb_tester
+     type: cb
+```
+
+Example payloads:
+
+```json
+{
+  "cb": "ack",
+  "some_other_field": true
+}
+```
+
+```json
+{
+  "cb": ["fail", "close"]
+}
+```
+
+Such an event or metadata will result in two CB insight events be sent back, one `fail` event, and one `close` event.
+
 ### debug
 
 The debug offramp is used to get an overview of how many events are put in wich classification.

--- a/docs/artefacts/onramps.md
+++ b/docs/artefacts/onramps.md
@@ -77,7 +77,7 @@ Supported configuration options are:
 - `brokers` - Broker servers to connect to. (Kafka nodes)
 - `rdkafka_options` - A optional map of an option to value, where both sides need to be strings.
 - `retry_failed_events` - If set to `false` the source will **not** seek back the consumer offset upon a failed events and thus not retry those when `enable.auto.commit` is set to `false` in `rdkafka_options`. (default `true`)
-- `poll_interval` - Duration to wait until we poll again if no message is in the kafka queue. (default: `100`)
+- `poll_interval` - Duration in milliseconds to wait until we poll again if no message is in the kafka queue. (default: `100`)
 
 Example:
 

--- a/docs/artefacts/onramps.md
+++ b/docs/artefacts/onramps.md
@@ -44,190 +44,49 @@ The column `Delivery Acknowledgements` describes when the onramp considers and r
 
 Onramp     | Delivery Acknowledgements                                           |
 -----------|---------------------------------------------------------------------|
-kafka      | always, only on `ack` event if `enable.auto.commit` is set to false |
-udp        | not supported                                                       |
-tcp        | not supported                                                       |
-file       | not supported                                                       |
 blaster    | not supported                                                       |
-metronome  | not supported                                                       |
 crononome  | not supported                                                       |
-rest       | not supported                                                       |
+discord    | not supported
+file       | not supported                                                       |
+kafka      | always, only on `ack` event if `enable.auto.commit` is set to false |
+metronome  | not supported                                                       |
 PostgreSQL | not supported                                                       |
+rest       | not supported                                                       |
+tcp        | not supported                                                       |
+udp        | not supported                                                       |
 ws         | not supported                                                       |
 
 
 ## Supported Onramps
+### blaster
 
-### kafka
+NOTE: This onramp is for benchmarking use, it should not be deployed in a live production system.
 
-The Kafka onramp connects to one or more Kafka topics. It uses librdkafka to handle connections and can use the full set of [librdkafka 1.5.0 configuration options](https://github.com/edenhill/librdkafka/blob/v1.5.0/CONFIGURATION.md).
-
-The default [codec](codecs.md#json) is `json`.
-
-The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
-
-```
-tremor-kafka://<config_first_broker_host>[:<config_first_broker_port>]/<topic>/<partition>/<offset>
-```
-
-Supported configuration options are:
-
-- `group_id` - The Kafka consumer group id to use.
-- `topics` - A list of topics to subscribe to.
-- `brokers` - Broker servers to connect to. (Kafka nodes)
-- `rdkafka_options` - A optional map of an option to value, where both sides need to be strings.
-- `retry_failed_events` - If set to `false` the source will **not** seek back the consumer offset upon a failed events and thus not retry those when `enable.auto.commit` is set to `false` in `rdkafka_options`. (default `true`)
-- `poll_interval` - Duration in milliseconds to wait until we poll again if no message is in the kafka queue. (default: `100`)
-
-Example:
-
-```yaml
-onramp:
-  - id: kafka-in
-    type: kafka
-    codec: json
-    config:
-      brokers:
-        - kafka:9092
-      topics:
-        - demo
-        - snotbadger
-      group_id: demo
-```
-
-A more involved example, only committing on successful circuit breaker event and not retrying failed events, while also decreasing the poll interval to 10ms to get notified of new messages faster:
-
-```yaml
-onramp:
-  - id: involved-kafka
-    type: kafka
-    codec: msgpack
-    preprocessors:
-      - lines
-    config:
-      brokers:
-        - kafka01:9092
-        - kafka02:9092
-      topics:
-        - my_topic
-      group_id: my_group_id
-      retry_failed_events: false
-      poll_interval: 10
-      rdkafka_options:
-        'enable.auto.commit': false
-```
-
-#### Semantics with `enable.auto.commit`
-
-If `enable.auto.commit: false` is set in `rdkafka_options`, the consumer offset in kafka will only be committed when the event has been successfully reached the other end of the pipeline (typically some [offramp](offramps.md#offramps) ).
-If an event failed during processing within the pipeline or at a downstream offramp, the consumer offset will be reset to the offset of the failed event, so it will be retried. This has some consequences worth mentioning:
-
-* Already processed kafka messages (that have succeeded before the failed message failed) might be seen again multiple times.
-* If the message is persistently failing (e.g. due to an illegal payload or similar), tremor will retry those messages infinitely.
-
-If persistent failures are tp be expected (e.g. due to invalid event payloads) or if repeating messages in general are a problem for, avoiding retries with `retry_failed_events: false` is advised.
-
-If `enable.auto.commit: true` is set in `rdkafka_options`, this is the default behaviour if nothing is specified, the offset is immediately committed upon event reception in tremor, regardless of success or failure of processing the kafka message as event in tremor.
-
-### udp
-
-The UDP onramp allows receiving data via UDP datagrams.
-
-The default [codec](codecs.md#string) is `string`.
-
-The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
-
-```
-tremor-udp://<sender_ip>:<sender_port>/<config_receive_port>
-```
-
-Supported configuration options are:
-
-- `host` - The IP to listen on
-- `port` - The Port to listen on
-
-Example:
-
-```yaml
-onramp:
-  - id: udp
-    type: udp
-    codec: json
-    config:
-      host: "127.0.0.1"
-      port: 9000
-```
-
-#### udp onramp example for [GELF](https://docs.graylog.org/en/latest/pages/gelf.html#gelf-via-udp)
-
-```yaml
-onramp:
-  - id: gelf-udp
-    type: udp
-    preprocessors:
-      - decompress
-      - gelf-chunking
-      - decompress
-    codec: json
-    config:
-      host: "127.0.0.1"
-      port: 12201
-```
-
-### file
-
-The file onramp reads the content of a file, line by line. And sends each line as an event. It has the ability to shut down the system upon completion. Files can be `xz` compressed.
+The blaster onramp is built for performance testing, but it can be used for spaced-out replays of events as well. Files to replay can be `xz` compressed. It will keep looping over the file.
 
 The default [codec](codecs.md#json) is `json`.
 
 The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
 
 ```
-tremor-file://<tremor-host.local>/<config_source_file>
+tremor-blaster://<tremor-host.local>/<config_source_file>
 ```
 
 Supported configuration options are:
 
 - `source` - The file to read from.
-- `close_on_done` - Terminates tremor once the file is processed.
-- `sleep_on_done` - Waits for the given number of milliseconds, before terminating tremor. Intended to be used with `close_on_done`.
+- `interval` - The interval in which events are sent in nanoseconds.
+- `iters` - Number of times the file will be repeated.
 
 Example:
 
 ```yaml
 onramp:
-  - id: in
-    type: file
+  - id: blaster
+    type: blaster
+    codec: json
     config:
-      source: /my/path/to/a/file.json
-      close_on_done: true
-      sleep_on_done: 1000 # wait for a second before terminating
-```
-
-### metronome
-
-This sends a periodic tick downstream. It is an excellent tool to generate some test traffic to validate pipelines.
-
-The default [codec](codecs.md#pass) is `pass`. (since we already output decoded JSON)
-
-The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
-
-```
-tremor-metronome://<tremor-host.local>/<config_interval>
-```
-
-Supported configuration options are:
-
-- `interval` - The interval in which events are sent in milliseconds.
-
-Example:
-
-```yaml
-onramp:
-  - id: metronome
-    type: metronome
-    config:
-      interval: 10000
+      source: ./demo/data/data.json.xz
 ```
 
 ### crononome
@@ -271,242 +130,6 @@ onramp:
 Cron entries that are historic or in the past ( relative to the current UTC time ) will be ignored.
 Cron entries beyond 2038 will not work due to underlying libraries ( rust, chrono, cron.rs ) suffering
 from the [year 2038 problem](https://en.wikipedia.org/wiki/Year_2038_problem).
-
-### blaster
-
-NOTE: This onramp is for benchmarking use, it should not be deployed in a live production system.
-
-The blaster onramp is built for performance testing, but it can be used for spaced-out replays of events as well. Files to replay can be `xz` compressed. It will keep looping over the file.
-
-The default [codec](codecs.md#json) is `json`.
-
-The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
-
-```
-tremor-blaster://<tremor-host.local>/<config_source_file>
-```
-
-Supported configuration options are:
-
-- `source` - The file to read from.
-- `interval` - The interval in which events are sent in nanoseconds.
-- `iters` - Number of times the file will be repeated.
-
-Example:
-
-```yaml
-onramp:
-  - id: blaster
-    type: blaster
-    codec: json
-    config:
-      source: ./demo/data/data.json.xz
-```
-
-### tcp
-
-This listens on a specified port for inbound tcp data.
-
-The onramp can leverage preprocessors to segment data before codecs are applied and events are forwarded
-to pipelines.
-
-The default [codec](codecs.md#json) is `json`.
-
-The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
-
-```
-tremor-tcp://<client_ip>:<client_port>/<config_server_port>
-```
-
-Supported configuration options are:
-
-- `host` - The IP to listen on
-- `port` - The Port to listen on
-
-Example:
-
-```yaml
-onramp:
-  - id: tcp
-    type: tcp
-    preprocessors:
-      - base64
-      - lines
-    codec: json
-    config:
-      host: "127.0.0.1"
-      port: 9000
-```
-
-#### tcp onramp example for [GELF](https://docs.graylog.org/en/latest/pages/gelf.html#gelf-via-tcp)
-
-```yaml
-onramp:
-  - id: gelf-tcp
-    type: tcp
-    preprocessors:
-      - lines-null
-    codec: json
-    config:
-      host: "127.0.0.1"
-      port: 12201
-```
-
-### rest
-
-**This onramp can be linked**
-
-The rest onramp listens on a specified port for inbound RESTful ( http ) data, treating the decoded and preprocessed http body as event data (and attaching other request attributes as event metadata).
-
-The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
-
-```
-tremor-rest://<tremor-rest-client-host.remote>
-```
-
-Supported configuration options are:
-
-- `host` - The host to advertise as
-- `port` - The TCP port to listen on
-
-The rest onramp respects the HTTP [Content-Type header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) and will use it to decode the request body when it's present (otherwise it defaults to using the codec specified in the onramp config).
-
-Tremor supports a limited set of builtin codecs used for well known MIME types (e.g. `application/json`, `application/yaml`, `text/plain`). In order to customize how certain `Content-Type`s are handled, provide a `codec_map` providing a mapping from MIME type to Tremor codec in the top level artifact config (where the `codec` is set).
-
-Set metadata variables:
-
-- `$request` - A record capturing the HTTP request attributes. Available fields within:
-    - `url` - A record with the following standard URL fields (optional fields might not be present):
-        - `scheme` - String, typically `http`
-        - `username` - String, optional
-        - `password` - String, optional
-        - `host` - String
-        - `port` - number, optional, absence means `80`
-        - `path` - String
-        - `query` - String, optional
-        - `fragment` - String, optional
-    - `method` - HTTP method used by the incoming request
-    - `headers` - A record that maps header name (lowercase string) to values (array of strings)
-
-Used metadata variables:
-
-> These variables can be used to dynamically change how responses are handled when using this onramp as [linked transport](../operations/linked-transports.md):
-
-- `$response` - A record capturing the HTTP response attributes. Available fields within:
-    - `status` - Numeric HTTP status code. (optional. status code defaults to `200` when not set)
-    - `headers` - A record that maps header name (string) to value (string or array of strings) (optional)
-
-When not used as a linked onramp, the status code returned with the response is `202`.
-
-Example:
-
-```yaml
-onramp:
-  - id: rest
-    type: rest
-    preprocessors:
-      - lines
-    codec: json
-    codec_map:
-      "text/html": "string"
-    config:
-      host: "localhost"
-      port: 9000
-```
-
-Known limitations:
-
-It is currently not possible to configure rest onramps via swagger, RAML or OpenAPI configuration files.
-
-### PostgreSQL
-
-PostgreSQL onramp.
-
-Supported configuration options are:
-
-- `host` - PostgreSQL database hostname
-- `port` - PostgresSQL database port
-- `user` - Username for authentication
-- `password` - Password for authentication
-- `dbname` - Database name
-- `query` - Query run to retrieve data
-- `interval_ms` - Query interval in milliseconds
-- `cache` - Location (`path`) and size (`size`) for caching of latest successful query interval
-
-`query` must include two arguments to be filled with start and end interval timestamps.
-
-Data will come out of onramp in objects representing columns. If schema
-specifies there are two fields, `username` (`VARCHAR`) and `created_at`
-(`TIMESTAMPTZ`) then the actual JSON coming out of onramp looks like:
-
-```
-"username": {
-  "fieldType": "VARCHAR",
-  "name": "username",
-  "value": "actual\_username"
-},
-"created\_at": {
-  "fieldType": "TIMESTAMPTZ",
-  "name": "created\_at",
-  "value": "2020-04-04 00:00:00.000000 +00:00"
-}
-```
-
-Example:
-
-```yml
-id: db
-type: postgres
-codec: json
-config:
-  host: localhost
-  port: 5432
-  user: postgres
-  password: example
-  dbname: sales
-  query: "SELECT id, name from events WHERE produced_at <= $1 AND produced_at > $2"
-  interval_ms: 1000
-  cache:
-    path: "/path/to/cache.json"
-    size: 4096
-```
-
-### ws
-
-**This onramp can be linked**
-
-Websocket onramp. Receiving either binary or text packages from a websocket connection. the url is: `ws://<host>:<port>/`
-
-The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
-
-```
-tremor-ws://<tremor-ws-client-host.remote>
-```
-
-Supported configuration options are:
-
-- `host` - The IP to listen on
-- `port` - The Port to listen on
-
-Set metadata variables:
-
-- `$binary` - `true` if the incoming websocket message came as binary (`false` otherwise)
-
-Used metadata variables (for reply with [linked transports](../operations/linked-transports.md)):
-
-- `$binary` - If reply data should be send as binary instead of text (optional. data format defaults to text when not set).
-
-Example:
-
-```yaml
-onramp:
-  - id: ws
-    type: ws
-    codec: json
-    config:
-      port: 12201
-      host: "127.0.0.1"
-```
 
 ### discord
 
@@ -602,3 +225,384 @@ Replies send to this onramp can perform multiple operations:
   }
 }}
 ```
+
+### file
+
+The file onramp reads the content of a file, line by line. And sends each line as an event. It has the ability to shut down the system upon completion. Files can be `xz` compressed.
+
+The default [codec](codecs.md#json) is `json`.
+
+The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
+
+```
+tremor-file://<tremor-host.local>/<config_source_file>
+```
+
+Supported configuration options are:
+
+- `source` - The file to read from.
+- `close_on_done` - Terminates tremor once the file is processed.
+- `sleep_on_done` - Waits for the given number of milliseconds, before terminating tremor. Intended to be used with `close_on_done`.
+
+Example:
+
+```yaml
+onramp:
+  - id: in
+    type: file
+    config:
+      source: /my/path/to/a/file.json
+      close_on_done: true
+      sleep_on_done: 1000 # wait for a second before terminating
+```
+
+
+
+### kafka
+
+The Kafka onramp connects to one or more Kafka topics. It uses librdkafka to handle connections and can use the full set of [librdkafka 1.5.0 configuration options](https://github.com/edenhill/librdkafka/blob/v1.5.0/CONFIGURATION.md).
+
+The default [codec](codecs.md#json) is `json`.
+
+The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
+
+```
+tremor-kafka://<config_first_broker_host>[:<config_first_broker_port>]/<topic>/<partition>/<offset>
+```
+
+Supported configuration options are:
+
+- `group_id` - The Kafka consumer group id to use.
+- `topics` - A list of topics to subscribe to.
+- `brokers` - Broker servers to connect to. (Kafka nodes)
+- `rdkafka_options` - A optional map of an option to value, where both sides need to be strings.
+- `retry_failed_events` - If set to `false` the source will **not** seek back the consumer offset upon a failed events and thus not retry those when `enable.auto.commit` is set to `false` in `rdkafka_options`. (default `true`)
+- `poll_interval` - Duration in milliseconds to wait until we poll again if no message is in the kafka queue. (default: `100`)
+
+Example:
+
+```yaml
+onramp:
+  - id: kafka-in
+    type: kafka
+    codec: json
+    config:
+      brokers:
+        - kafka:9092
+      topics:
+        - demo
+        - snotbadger
+      group_id: demo
+```
+
+A more involved example, only committing on successful circuit breaker event and not retrying failed events, while also decreasing the poll interval to 10ms to get notified of new messages faster:
+
+```yaml
+onramp:
+  - id: involved-kafka
+    type: kafka
+    codec: msgpack
+    preprocessors:
+      - lines
+    config:
+      brokers:
+        - kafka01:9092
+        - kafka02:9092
+      topics:
+        - my_topic
+      group_id: my_group_id
+      retry_failed_events: false
+      poll_interval: 10
+      rdkafka_options:
+        'enable.auto.commit': false
+```
+
+#### Semantics with `enable.auto.commit`
+
+If `enable.auto.commit: false` is set in `rdkafka_options`, the consumer offset in kafka will only be committed when the event has been successfully reached the other end of the pipeline (typically some [offramp](offramps.md#offramps) ).
+If an event failed during processing within the pipeline or at a downstream offramp, the consumer offset will be reset to the offset of the failed event, so it will be retried. This has some consequences worth mentioning:
+
+* Already processed kafka messages (that have succeeded before the failed message failed) might be seen again multiple times.
+* If the message is persistently failing (e.g. due to an illegal payload or similar), tremor will retry those messages infinitely.
+
+If persistent failures are tp be expected (e.g. due to invalid event payloads) or if repeating messages in general are a problem for, avoiding retries with `retry_failed_events: false` is advised.
+
+If `enable.auto.commit: true` is set in `rdkafka_options`, this is the default behaviour if nothing is specified, the offset is immediately committed upon event reception in tremor, regardless of success or failure of processing the kafka message as event in tremor.
+
+### metronome
+
+This sends a periodic tick downstream. It is an excellent tool to generate some test traffic to validate pipelines.
+
+The default [codec](codecs.md#pass) is `pass`. (since we already output decoded JSON)
+
+The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
+
+```
+tremor-metronome://<tremor-host.local>/<config_interval>
+```
+
+Supported configuration options are:
+
+- `interval` - The interval in which events are sent in milliseconds.
+
+Example:
+
+```yaml
+onramp:
+  - id: metronome
+    type: metronome
+    config:
+      interval: 10000
+```
+
+### PostgreSQL
+
+PostgreSQL onramp.
+
+Supported configuration options are:
+
+- `host` - PostgreSQL database hostname
+- `port` - PostgresSQL database port
+- `user` - Username for authentication
+- `password` - Password for authentication
+- `dbname` - Database name
+- `query` - Query run to retrieve data
+- `interval_ms` - Query interval in milliseconds
+- `cache` - Location (`path`) and size (`size`) for caching of latest successful query interval
+
+`query` must include two arguments to be filled with start and end interval timestamps.
+
+Data will come out of onramp in objects representing columns. If schema
+specifies there are two fields, `username` (`VARCHAR`) and `created_at`
+(`TIMESTAMPTZ`) then the actual JSON coming out of onramp looks like:
+
+```
+"username": {
+  "fieldType": "VARCHAR",
+  "name": "username",
+  "value": "actual\_username"
+},
+"created\_at": {
+  "fieldType": "TIMESTAMPTZ",
+  "name": "created\_at",
+  "value": "2020-04-04 00:00:00.000000 +00:00"
+}
+```
+
+Example:
+
+```yml
+id: db
+type: postgres
+codec: json
+config:
+  host: localhost
+  port: 5432
+  user: postgres
+  password: example
+  dbname: sales
+  query: "SELECT id, name from events WHERE produced_at <= $1 AND produced_at > $2"
+  interval_ms: 1000
+  cache:
+    path: "/path/to/cache.json"
+    size: 4096
+```
+
+### rest
+
+**This onramp can be linked**
+
+The rest onramp listens on a specified port for inbound RESTful ( http ) data, treating the decoded and preprocessed http body as event data (and attaching other request attributes as event metadata).
+
+The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
+
+```
+tremor-rest://<tremor-rest-client-host.remote>
+```
+
+Supported configuration options are:
+
+- `host` - The host to advertise as
+- `port` - The TCP port to listen on
+
+The rest onramp respects the HTTP [Content-Type header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) and will use it to decode the request body when it's present (otherwise it defaults to using the codec specified in the onramp config).
+
+Tremor supports a limited set of builtin codecs used for well known MIME types (e.g. `application/json`, `application/yaml`, `text/plain`). In order to customize how certain `Content-Type`s are handled, provide a `codec_map` providing a mapping from MIME type to Tremor codec in the top level artifact config (where the `codec` is set).
+
+Set metadata variables:
+
+- `$request` - A record capturing the HTTP request attributes. Available fields within:
+    - `url` - A record with the following standard URL fields (optional fields might not be present):
+        - `scheme` - String, typically `http`
+        - `username` - String, optional
+        - `password` - String, optional
+        - `host` - String
+        - `port` - number, optional, absence means `80`
+        - `path` - String
+        - `query` - String, optional
+        - `fragment` - String, optional
+    - `method` - HTTP method used by the incoming request
+    - `headers` - A record that maps header name (lowercase string) to values (array of strings)
+
+Used metadata variables:
+
+> These variables can be used to dynamically change how responses are handled when using this onramp as [linked transport](../operations/linked-transports.md):
+
+- `$response` - A record capturing the HTTP response attributes. Available fields within:
+    - `status` - Numeric HTTP status code. (optional. status code defaults to `200` when not set)
+    - `headers` - A record that maps header name (string) to value (string or array of strings) (optional)
+
+When not used as a linked onramp, the status code returned with the response is `202`.
+
+Example:
+
+```yaml
+onramp:
+  - id: rest
+    type: rest
+    preprocessors:
+      - lines
+    codec: json
+    codec_map:
+      "text/html": "string"
+    config:
+      host: "localhost"
+      port: 9000
+```
+
+Known limitations:
+
+It is currently not possible to configure rest onramps via swagger, RAML or OpenAPI configuration files.
+
+### tcp
+
+This listens on a specified port for inbound tcp data.
+
+The onramp can leverage preprocessors to segment data before codecs are applied and events are forwarded
+to pipelines.
+
+The default [codec](codecs.md#json) is `json`.
+
+The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
+
+```
+tremor-tcp://<client_ip>:<client_port>/<config_server_port>
+```
+
+Supported configuration options are:
+
+- `host` - The IP to listen on
+- `port` - The Port to listen on
+
+Example:
+
+```yaml
+onramp:
+  - id: tcp
+    type: tcp
+    preprocessors:
+      - base64
+      - lines
+    codec: json
+    config:
+      host: "127.0.0.1"
+      port: 9000
+```
+
+#### tcp onramp example for [GELF](https://docs.graylog.org/en/latest/pages/gelf.html#gelf-via-tcp)
+
+```yaml
+onramp:
+  - id: gelf-tcp
+    type: tcp
+    preprocessors:
+      - lines-null
+    codec: json
+    config:
+      host: "127.0.0.1"
+      port: 12201
+```
+
+
+### udp
+
+The UDP onramp allows receiving data via UDP datagrams.
+
+The default [codec](codecs.md#string) is `string`.
+
+The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
+
+```
+tremor-udp://<sender_ip>:<sender_port>/<config_receive_port>
+```
+
+Supported configuration options are:
+
+- `host` - The IP to listen on
+- `port` - The Port to listen on
+
+Example:
+
+```yaml
+onramp:
+  - id: udp
+    type: udp
+    codec: json
+    config:
+      host: "127.0.0.1"
+      port: 9000
+```
+
+#### udp onramp example for [GELF](https://docs.graylog.org/en/latest/pages/gelf.html#gelf-via-udp)
+
+```yaml
+onramp:
+  - id: gelf-udp
+    type: udp
+    preprocessors:
+      - decompress
+      - gelf-chunking
+      - decompress
+    codec: json
+    config:
+      host: "127.0.0.1"
+      port: 12201
+```
+
+### ws
+
+**This onramp can be linked**
+
+Websocket onramp. Receiving either binary or text packages from a websocket connection. the url is: `ws://<host>:<port>/`
+
+The event [origin URI](../tremor-script/stdlib/tremor/origin.md) set by the onramp is of the form:
+
+```
+tremor-ws://<tremor-ws-client-host.remote>
+```
+
+Supported configuration options are:
+
+- `host` - The IP to listen on
+- `port` - The Port to listen on
+
+Set metadata variables:
+
+- `$binary` - `true` if the incoming websocket message came as binary (`false` otherwise)
+
+Used metadata variables (for reply with [linked transports](../operations/linked-transports.md)):
+
+- `$binary` - If reply data should be send as binary instead of text (optional. data format defaults to text when not set).
+
+Example:
+
+```yaml
+onramp:
+  - id: ws
+    type: ws
+    codec: json
+    config:
+      port: 12201
+      host: "127.0.0.1"
+```
+

--- a/docs/artefacts/onramps.md
+++ b/docs/artefacts/onramps.md
@@ -76,6 +76,8 @@ Supported configuration options are:
 - `topics` - A list of topics to subscribe to.
 - `brokers` - Broker servers to connect to. (Kafka nodes)
 - `rdkafka_options` - A optional map of an option to value, where both sides need to be strings.
+- `retry_failed_events` - If set to `false` the source will **not** seek back the consumer offset upon a failed events and thus not retry those when `enable.auto.commit` is set to `false` in `rdkafka_options`. (default `true`)
+- `poll_interval` - Duration to wait until we poll again if no message is in the kafka queue. (default: `100`)
 
 Example:
 
@@ -91,6 +93,28 @@ onramp:
         - demo
         - snotbadger
       group_id: demo
+```
+
+A more involved example, only committing on successful circuit breaker event and not retrying failed events, while also decreasing the poll interval to 10ms to get notified of new messages faster:
+
+```yaml
+onramp:
+  - id: involved-kafka
+    type: kafka
+    codec: msgpack
+    preprocessors:
+      - lines
+    config:
+      brokers:
+        - kafka01:9092
+        - kafka02:9092
+      topics:
+        - my_topic
+      group_id: my_group_id
+      retry_failed_events: false
+      poll_interval: 10
+      rdkafka_options:
+        'enable.auto.commit': false
 ```
 
 ### udp

--- a/docs/artefacts/onramps.md
+++ b/docs/artefacts/onramps.md
@@ -117,6 +117,18 @@ onramp:
         'enable.auto.commit': false
 ```
 
+#### Semantics with `enable.auto.commit`
+
+If `enable.auto.commit: false` is set in `rdkafka_options`, the consumer offset in kafka will only be committed when the event has been successfully reached the other end of the pipeline (typically some [offramp](offramps.md#offramps) ).
+If an event failed during processing within the pipeline or at a downstream offramp, the consumer offset will be reset to the offset of the failed event, so it will be retried. This has some consequences worth mentioning:
+
+* Already processed kafka messages (that have succeeded before the failed message failed) might be seen again multiple times.
+* If the message is persistently failing (e.g. due to an illegal payload or similar), tremor will retry those messages infinitely.
+
+If persistent failures are tp be expected (e.g. due to invalid event payloads) or if repeating messages in general are a problem for, avoiding retries with `retry_failed_events: false` is advised.
+
+If `enable.auto.commit: true` is set in `rdkafka_options`, this is the default behaviour if nothing is specified, the offset is immediately committed upon event reception in tremor, regardless of success or failure of processing the kafka message as event in tremor.
+
 ### udp
 
 The UDP onramp allows receiving data via UDP datagrams.


### PR DESCRIPTION
We might want to consider adding a numeric config called `max_retries` which limits how often a failed message is retried until it is skipped. Otherwise we might run into infinite loops when `enable.auto.commit: false` is set and events result in failures persistently. Any thoughts on this?