### PR TITLE
Add docs for request metadata in response

### DIFF
--- a/docs/artefacts/offramps.md
+++ b/docs/artefacts/offramps.md
@@ -583,6 +583,10 @@ Set metadata variables:
 - `$response` - A record capturing the HTTP response attributes. Available fields within:
     - `status` - Numeric HTTP status code
     - `headers` - A record that maps header name (lowercase string) to value (array of strings)
+- `$request` - A record with the related HTTP request attributes. Available fields within:
+    - `method` - HTTP method used
+    - `headers` - A record containing all the request headers
+    - `endpoint` - A record containing all the fields that config `endpoint` does
 
 When used as a linked offramp, batched events are rejected by the offramp.
 


### PR DESCRIPTION
Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>

Include request headers, method and endpoint as a metadata variable for response events.