### PR TITLE
Adapt to new select target restrictions

### DIFF
--- a/docs/tremor-query/index.md
+++ b/docs/tremor-query/index.md
@@ -120,7 +120,7 @@ Tremor supports tumbling windows by number of events or by time.
 General configuration Parameters:
 
 * `eviction_period`: duration in nanoseconds without events arriving, after which to evict / remove the current window data for a single group.
-* `max_groups`: maximum number of groups to maintain simultaneously in memory. Groups added beyond that number will be ignored. Per default, tremor allows as much groups as will fit into memory.
+* `max_groups`: maximum number of groups to maintain simultaneously in memory. Groups added beyond that number will be ignored. Per default, tremor does not impose any limit on the number of groups kept simultaneously.
 
 Each select statement maintains the groups for the current windows in an in memory data-structure. This contains the group values as well as the aggregate states.
 If your grouping values possibly have a very high cardinality it is possible to end up with runaway memory growth, as per default the group data structures won't be evicted,
@@ -153,7 +153,10 @@ independent from event flow with a granularity of `100ms`. It is thus possible t
 Configuration Parameters:
 
 - `interval`: Time interval in nanoseconds after which the window closes.
-- `emit_empty_windows` - By default, time based windows will only emit, if events arrived. By configuring `emit_empty_windows` as `true` this window will emit every `interval`, regardless if events arrived or not. If you use this in a `group by` query and the cardinality is likely huge, consider using `max_groups` and `eviction_period` to avoid runaway memory growth such a window will one event per interval and group for which we've seen events before.
+- `emit_empty_windows` - By default, time based windows will only emit, if events arrived. By configuring `emit_empty_windows` as `true` this window will emit every `interval`, regardless if events arrived or not.
+
+!!! warning
+    If you use a window with `emit_empty_windows` in a `group by` query and the cardinality is likely huge, consider using `max_groups` and `eviction_period` to avoid runaway memory growth such a window will one event per interval and group for which we've seen events before.
 
 
 Window definition grammar:

--- a/docs/workshop/examples/11_influx/etc/tremor/config/00_ramps.yaml
+++ b/docs/workshop/examples/11_influx/etc/tremor/config/00_ramps.yaml
@@ -15,6 +15,8 @@ offramp:
   - id: influx-output
     type: rest # an influxdb offramp
     codec: influx
+    postprocessors:
+      - lines
     config:
       endpoint:
         host: influxdb

--- a/docs/workshop/examples/11_influx/etc/tremor/config/01_binding.yaml
+++ b/docs/workshop/examples/11_influx/etc/tremor/config/01_binding.yaml
@@ -7,8 +7,11 @@ binding:
   - id: example                                     # The unique name of this binding template
     links:
       '/onramp/udp-input/{instance}/out':            # Connect the inpunt to the pipeline
-       - '/pipeline/example/{instance}/in'
+        - '/pipeline/system::passthrough/{instance}/in'
+        - '/pipeline/example/{instance}/in'
+      '/pipeline/system::passthrough/{instance}/out':
+        - '/offramp/debug2/{instance}/in'
       '/pipeline/example/{instance}/out':           # Connect the pipeline to the output
-       - '/offramp/influx-output/{instance}/in'
+        - '/offramp/influx-output/{instance}/in'
       '/pipeline/example/{instance}/err':           # Connect the pipeline to the output
-       - '/offramp/system::stdout/{instance}/in'
+        - '/offramp/system::stdout/{instance}/in'

--- a/docs/workshop/examples/11_influx/etc/tremor/config/example.trickle
+++ b/docs/workshop/examples/11_influx/etc/tremor/config/example.trickle
@@ -3,12 +3,12 @@ use std::record;
 
 define tumbling window `10secs`
 with
-   interval = 10000
+   interval = core::datetime::with_seconds(10)
 end;
 
 define tumbling window `1min`
 with
-   interval = 60000
+   interval = core::datetime::with_minutes(1)
 end;
 
 create stream normalize;
@@ -33,10 +33,10 @@ select {
 from in
 group by set(event.measurement, event.tags, each(record::keys(event.fields)))
 into aggregate
-having type::is_number(event.value); 
+having type::is_number(event.value);
 
 
-select 
+select
 {
     "measurement": event.measurement,
     "tags": patch event.tags of insert "window" => window end,


### PR DESCRIPTION
Adapt docs to new restrictions for the select target expression introduced in: https://github.com/tremor-rs/tremor-runtime/pull/828

