### PR TITLE
Fix Typo

### DIFF
--- a/docs/tremor-script/index.md
+++ b/docs/tremor-script/index.md
@@ -67,7 +67,7 @@ Literal in `tremor-script` are equivalent to their sibling types supported by th
 
 #### Null
 
-The null literal which represents the abscence of a defined value
+The null literal which represents the absence of a defined value
 
 ```tremor
 null


### PR DESCRIPTION
The null literal which represents the ~abscence~ absence of a defined value

Signed-off-by: yatinmaan <yatinmaan1@gmail.com>