### PR TITLE
Fix a lot of typos

### DIFF
--- a/docs/CII.md
+++ b/docs/CII.md
@@ -222,7 +222,7 @@ Met.
 
 **The project MUST enable one or more compiler warning flags, a "safe" language mode, or use a separate "linter" tool to look for code quality errors or common simple mistakes, if there is at least one FLOSS tool that can implement this criterion in the selected language.**
 
-Met. The project enables all warnings and enforces strict / pendantic checks on code style, format. These are constraints and limitations are enforced by the build and continuous integration systems.
+Met. The project enables all warnings and enforces strict / pedantic checks on code style, format. These are constraints and limitations are enforced by the build and continuous integration systems.
 
 **The project MUST address warnings.**
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,7 +46,7 @@ is unique.
 
 Returns artefact data, on success.
 
-If an arterfact of the same name already exists, a conflict error is returned.
+If an artefact of the same name already exists, a conflict error is returned.
 
 Response data may be either JSON or YAML formatted ( defaults to JSON ).
 
@@ -142,7 +142,7 @@ is unique.
 
 Returns artefact data, on success.
 
-If an arterfact of the same name already exists, a conflict error is returned.
+If an artefact of the same name already exists, a conflict error is returned.
 
 Response data may be either JSON or YAML formatted ( defaults to JSON ).
 

--- a/docs/artefacts/codecs.md
+++ b/docs/artefacts/codecs.md
@@ -10,7 +10,7 @@ En- and decodes [JSON](https://json.org), for encoding a minified format is used
 
 ### string
 
-Treats the event as non structured string. It is required that the input **is valid utf8** or the decoding will fail.
+Treats the event as non structured string. It is required that the input **is valid UTF-8** or the decoding will fail.
 
 ### msgpack
 
@@ -45,18 +45,18 @@ The Binflux codec is a binary representation of influx data that is significantl
 
 The format itself does not include framing but can be used with the `size-prefix` pre/post processors.
 
-For all numbers netwokr byte order is used (big endian). The data is represented as follows:
+For all numbers network byte order is used (big endian). The data is represented as follows:
 
 1. _2 byte_ (u16) length of the `measurement` in bytes
 2. _n byte_ (utf8) the measurement (utf8 encoded string)
 3. _8 byte_ (u64) the timestamp
 4. _2 byte_ (u16) number of tags (key value pairs) repetitions of:
-   1. _2 byte_ (u16) lenght of the tag name in bytes
+   1. _2 byte_ (u16) length of the tag name in bytes
    2. _n byte_ (utf8) tag name (utf8 encoded string)
-   3. _2 byte_ (u16) lenght of tag value in bytes
+   3. _2 byte_ (u16) length of tag value in bytes
    4. _n byte_ (utf8) tag value (utf8 encoded string)
 5. _2 byte_ (u16) number of fiends (key value pairs) repetition of:
-   1. _2 byte_ (u16) lenght of the tag name in bytes
+   1. _2 byte_ (u16) length of the tag name in bytes
    2. _n byte_ (utf8) tag name (utf8 encoded string)
    3. _1 byte_ (tag) type of the field value can be one of:
    4. `TYPE_I64 = 0` followed by _8 byte_ (i64)

--- a/docs/artefacts/offramps.md
+++ b/docs/artefacts/offramps.md
@@ -286,7 +286,7 @@ To indicate successful termination, an `exit` status of zero may be used:
 { "exit": 0 }
 ```
 
-To indicate non-succesful termination, a non-zero `exit` status may be used:
+To indicate non-successful termination, a non-zero `exit` status may be used:
 
 ```json
 { "exit": 1 }
@@ -380,7 +380,7 @@ offramp:
 
 The kv offramp is intended to allow for a decuple way of persisting and retrieving state in a non blocking way.
 
-Events send to the KV offramp are commands the following commands are supported:
+Events sent to the KV offramp are commands. The following are supported:
 
 Example:
 ```yaml
@@ -450,7 +450,7 @@ Reads a range of keys
 {"scan": {
    "start": "<string|binary>", // optional, if not set will start with the first key
    "end": "<string|binary>", // optional, if not set will read to the end key
-}
+}}
 ```
 **Response**:
 ```js
@@ -487,14 +487,14 @@ Compare And Swap operation. Those operations require old values to match what it
 
 ### newrelic
 
-Send events to [New Relic](https://newrelic.com/) platform, using it's log apis (variable by region).
+Send events to [New Relic](https://newrelic.com/) platform, using its log apis (variable by region).
 
 This offramp encodes events as json, as this is required by the newrelic log api. Postprocessors are not used.
 
 Supported configuration options are:
 
 - `license_key` - New Relic's license (or insert only) key
-- `compress_logs` - Whther logs should be compressed before sending to New Relic  (avoids extra egress costs but at the cost of more cpu usage by tremor) (default: false)
+- `compress_logs` - Whether logs should be compressed before sending to New Relic  (avoids extra egress costs but at the cost of more cpu usage by tremor) (default: false)
 - `region` - Region to use to send logs. Available choices: usa, europe (default: usa)
 
 Example:
@@ -669,7 +669,7 @@ If `raw` is set to true, the event data will be put on stderr as is.
 Supported configuration options:
 
 - `prefix` - A prefix written before each event (optional string).
-- `raw` - Write evcent data bytes as is to stderr.
+- `raw` - Write event data bytes as is to stderr.
 
 Example:
 
@@ -698,7 +698,7 @@ If `raw` is set to true, the event data will be put on stdout as is.
 Supported configuration options:
 
 - `prefix` - A prefix written before each event (optional string).
-- `raw` - Write evcent data bytes as is to stdout.
+- `raw` - Write event data bytes as is to stdout.
 
 Example:
 
@@ -725,7 +725,7 @@ Supported configuration options are:
 - `port` - The TCP port to listen on
 - `is_non_blocking` - Is the socket configured as non-blocking ( default: false )
 - `ttl` - Set the socket's time-to-live ( default: 64 )
-- `is_no_delay` - Set the socket's nagle ( delay ) algorithm to off ( default: true )
+- `is_no_delay` - Set the socket's Nagle ( delay ) algorithm to off ( default: true )
 
 Example:
 

--- a/docs/artefacts/onramps.md
+++ b/docs/artefacts/onramps.md
@@ -94,7 +94,7 @@ onramp:
 ```
 ### cb
 
-The `cb` onramp is for testing how downstream pipeline and offramps issue circuit breaker events. It expects a circuit breaker event for each event it sent out, and then, the latest after the configured `timeout` is exceeded, it exits the tremor process. If some events didnt receive circuit breaker events, it exits with status code `1`, if everything is fine it exits with `0`.
+The `cb` onramp is for testing how downstream pipeline and offramps issue circuit breaker events. It expects a circuit breaker event for each event it sent out, and then, the latest after the configured `timeout` is exceeded, it exits the tremor process. If some events didn't receive circuit breaker events, it exits with status code `1`, if everything is fine it exits with `0`.
 
 Supported configuration options are:
 

--- a/docs/artefacts/postprocessors.md
+++ b/docs/artefacts/postprocessors.md
@@ -16,7 +16,7 @@ Encodes raw data into base64 encoded bytes.
 
 ### length-prefixed
 
-Prefixes the data with a network byte order (big endian) lenght of the data in bytes.
+Prefixes the data with a network byte order (big endian) length of the data in bytes.
 
 ### gelf-chunking
 

--- a/docs/artefacts/preprocessors.md
+++ b/docs/artefacts/preprocessors.md
@@ -88,4 +88,4 @@ Removes empty messages (aka zero len).
 
 ### length-prefixed
 
-Seperates a continous stream of data based on length prefixing. The length for each package in a stream is based on the first 64 bit decoded as an unsigned big endian value.
+Separates a continuous stream of data based on length prefixing. The length for each package in a stream is based on the first 64 bit decoded as an unsigned big endian value.

--- a/docs/development/issue-investigation.md
+++ b/docs/development/issue-investigation.md
@@ -10,7 +10,7 @@ Logs and metrics are the first and most fundamental tool when starting to invest
 
 ### `htop` (prod)
 
-Not really a debugging tool but a nice starting point to see values like memory consumption, cpu load both per process and per thread. Things to look out for are:
+Not really a debugging tool but a nice starting point to see values like memory consumption, CPU load both per process and per thread. Things to look out for are:
 
 - Memory consumption
 - CPU load
@@ -21,7 +21,7 @@ To a degree `top` can be used in its place if `htop` isn't available.
 
 ### `perf` (prod: Linux)
 
-Perf is a tool that is used to profile processes, it gives an overview over functions that cpu time is spend on. While it doesn't give a full trace but it is quite handy in situations where we have a hot function to find where a program is spending it time.
+Perf is a tool that is used to profile processes, it gives an overview over functions that CPU time is spend on. While it doesn't give a full trace but it is quite handy in situations where we have a hot function to find where a program is spending it time.
 
 It can be run to find where a program spends time:
 
@@ -111,7 +111,7 @@ We ran tremor extensively using the Leak profiler of Instruments to see if it co
 
 #### 2nd theory: Misconfigured librdkafka operations
 
-With the hint gained from the last investigation we looked at the configuration of the system. It showed that a number instances of Kafka onramps were used and the hosts it running un were under spaced regarding to what was communicated to us. Looking at the manual for librdkafka showed that by default each librdkafka instance would allocate up to 1GB of memory as a buffer. Running 4 instances at a 4GB of memory box with additional processes this would eventually lead to running out of memory.
+With the hint gained from the last investigation we looked at the configuration of the system. It showed that a number instances of Kafka onramps were used and the hosts it running on were under spaced regarding to what was communicated to us. Looking at the manual for librdkafka showed that by default each librdkafka instance would allocate up to 1GB of memory as a buffer. Running 4 instances at a 4GB of memory box with additional processes this would eventually lead to running out of memory.
 
 ##### prove of 2nd theory
 
@@ -196,7 +196,7 @@ Issues:
 - Setup was spanning the WAN using local Logstas and WAN connected Tremor causing MTU issues that was not documented and falsely attributed to tremor
 - Using a nonstandard conform GELF header for 'uncompressed' caused those datapoints to be discarded, this was falsely attributed to tremor
 - the UDP buffer on the Tremor and logstash hosts were configured differently causing the tremor host to have significantly less buffer causing some messages to be discarded in the OS UDP stack, this was falsely attributed to tremor
-- A tool called udp_replay was used to copy data from a logstash host to a tremor host, this tool truncated the UDP payload, this payload could no longer be decompressed making this packages fail, this was falsy attributed to trmeor
+- A tool called udp_replay was used to copy data from a logstash host to a tremor host, this tool truncated the UDP payload, this payload could no longer be decompressed making this packages fail, this was falsely attributed to tremor
 - Some clients send a empty tailing message with a bad segment index (n+1) causing error messages to appear in the logs, this is valid behavior but were flagged as a 'bug' in tremor because logstash does silently drop those.
 - Some clients reuse the sequence number - this can lead to bad messages when UDP packages interleave, tremor reports those incidents and will likely be flagged as buggy because of it.
 - MIO's UDP with edge-poll stops receiving data [ticket](https://github.com/tokio-rs/mio/issues/1076) we switched to level poll which solves this.

--- a/docs/development/quick-start.md
+++ b/docs/development/quick-start.md
@@ -80,7 +80,7 @@ To pick up the openssl libs during tremor build, you also have to set the `OPENS
 set OPENSSL_DIR=C:\Users\juju\TREMOR\vcpkg\installed\x64-windows-static
 ```
 
-Technically, the rust [openssl](https://docs.rs/openssl) crate will try to discover the openssl libs via vcpkg (as long as env var `VCPKGRS_DYNAMIC` is set), but that is not working for the recent openssl libs supplied by vcpkg. There's a [fix](https://github.com/sfackler/rust-openssl/pull/1238) for it and once that lands in a release for `rust-openssl` (and also starts getting used by tremor depenencies), we won't have to rely on the `OPENSSL_DIR` var.
+Technically, the rust [openssl](https://docs.rs/openssl) crate will try to discover the openssl libs via vcpkg (as long as env var `VCPKGRS_DYNAMIC` is set), but that is not working for the recent openssl libs supplied by vcpkg. There's a [fix](https://github.com/sfackler/rust-openssl/pull/1238) for it and once that lands in a release for `rust-openssl` (and also starts getting used by tremor dependencies), we won't have to rely on the `OPENSSL_DIR` var.
 
 ### Running Tremor
 
@@ -122,7 +122,7 @@ cargo fmt
 rustup component add clippy
 ```
 
-To run `clippy`, run the following comand:
+To run `clippy`, run the following command:
 
 ```bash
 cargo clippy

--- a/docs/operations/linked-transports.md
+++ b/docs/operations/linked-transports.md
@@ -69,7 +69,7 @@ Ramp artefacts that support linked transports are listed here:
 * [Websocket Onramp](../artefacts/onramps.md#ws)
 * [Websocket Offramp](../artefacts/onramps.md#ws)
 * [Discord onramp](../artefacts/onramps.md#discord)
-* [KV offramp](../artefacts/offramps.md#KV)
+* [KV offramp](../artefacts/offramps.md#kv)
 
 As part of the above docs, you will also find event metadata variables that these onramps/offramps set (and use), which can be utilized as part of the wider application built using these aretefacts.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -186,7 +186,7 @@ Data can be raw binary, JSON, MsgPack, Influx or other structures.
 
 When data is ingested into a Tremor pipeline it can be any **supported** format.
 
-Tremor pipeline operators however, often assume _some_ structure. For heirarchic or nested formats such as JSON and MsgPack, Tremor uses the `serde` serialisation and deserialisation capabilities.
+Tremor pipeline operators however, often assume _some_ structure. For hierarchic or nested formats such as JSON and MsgPack, Tremor uses the `serde` serialisation and deserialisation capabilities.
 
 Therefore, the _in-memory_ format for _JSON-like_ data in Tremor is effectively a `simd_json::Value`. This has the advantage of allowing Tremor-script to work against YAML, JSON or MsgPack data with no changes or considerations in the Tremor-script based on the origin data format.
 
@@ -196,7 +196,7 @@ For raw binary or other data formats, Tremor provides a growing set of codecs th
 
 In general, operators and developers should _minimize_ the number of encoding and decoding steps required in the transit of data through Tremor or between Tremor instances.
 
-The major overhead in most Tremor systems is encoding and decoding overhead. To compensate that, as JSON is the most dominent format, we [ported](https://github.com/simd-lite/simdjson-rs) [simd-json](https://github.com/lemire/simdjson) this reduces the cost of en- and decoding significantly compared to other JSON implementations in Rust.
+The major overhead in most Tremor systems is encoding and decoding overhead. To compensate that, as JSON is the most dominant format, we [ported](https://github.com/simd-lite/simdjson-rs) [simd-json](https://github.com/lemire/simdjson) this reduces the cost of en- and decoding significantly compared to other JSON implementations in Rust.
 
 ### Distribution model
 

--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -63,8 +63,8 @@ and full announcement.
 
 If you have not received a reply to your email within 48 hours, or have not heard from the security team for the past five days, there are a few steps you can take (in order):
 
-Contact the current security coordinator (Darach Ennis) directly [pgp key](https://pgp.mit.edu/pks/lookup?op=get&search=0x962FAC01B6989EBB).
-Contact the back-up contact (Heinz Gies) directly [pgp key](https://keys.openpgp.org/vks/v1/by-fingerprint/71C9D7794FCEAC9D77AC4F6FE21BB9BD3F38481E).
+Contact the current security coordinator (Darach Ennis) directly [PGP key](https://pgp.mit.edu/pks/lookup?op=get&search=0x962FAC01B6989EBB).
+Contact the back-up contact (Heinz Gies) directly [PGP key](https://keys.openpgp.org/vks/v1/by-fingerprint/71C9D7794FCEAC9D77AC4F6FE21BB9BD3F38481E).
 
 Post a friendly reminder on the community slack.
 

--- a/docs/tremor-query/index.md
+++ b/docs/tremor-query/index.md
@@ -38,7 +38,7 @@ Leveraging the tremor-query expression syntax allows rich filtering, transformat
 
 The addition of aggregate functions, and windowing allows batches or a slice in time of events to be summarised or processed together to derive useful synthetic events.
 
-Like its sibling langauge `tremor-script`, `tremor-query` supports the same data-types and is entirely event-driven. It has many parallels for existing tremor users to leverage while learning, yet it is powerful and flexible in its own right.
+Like its sibling language `tremor-script`, `tremor-query` supports the same data-types and is entirely event-driven. It has many parallels for existing tremor users to leverage while learning, yet it is powerful and flexible in its own right.
 
 ### Extensibility
 
@@ -46,7 +46,7 @@ The SQL-based nature of `tremor-query` means that complex branching, combining o
 
 The expression-based expression language derived from `tremor-script` allows computational forms to be extended.
 
-The language core is designed for reuse - currently the expression language is reused in the query langauge, as are the library of functions available to both. The addition of aggregate functions is currently exclusive to tremor-query as these are only relevant when processing multiple in-flight ( or cached ) events at the same time.
+The language core is designed for reuse - currently the expression language is reused in the query language, as are the library of functions available to both. The addition of aggregate functions is currently exclusive to tremor-query as these are only relevant when processing multiple in-flight ( or cached ) events at the same time.
 
 In the future, `tremor-query` may be retargeted as a JIT-compiled language and other domain specific languages may be integrated as the tremor runtime evolves to meet new uses, demands, and stake-holders.
 
@@ -230,7 +230,7 @@ Script definition grammar:
 
 > ![script definition grammar](grammar/diagram/DefineScriptDefn.png)
 > ![with partial params grammar](grammar/diagram/WithPartialParams.png)
-> ![embeded script grammar](grammar/diagram/EmbeddedScript.png)
+> ![embedded script grammar](grammar/diagram/EmbeddedScript.png)
 
 Script an operator:
 

--- a/docs/tremor-query/pp.md
+++ b/docs/tremor-query/pp.md
@@ -29,7 +29,7 @@ The `#!line` directive is a implementation detail mentioned here for the same of
 
 ## Config directive
 
-This directive allows compile-time configuration paraemters to be passed into tremor
+This directive allows compile-time configuration parameters to be passed into tremor
 
 ## Example preprocessed tremor-script
 

--- a/docs/tremor-query/walkthrough.md
+++ b/docs/tremor-query/walkthrough.md
@@ -232,7 +232,7 @@ To use a window we need to define the window specifications, such as a 15 second
 tumbling window called `15secs` as above. We can then create instances of these windows at runtime by
 applying those windows to streams. This is done in the `from` clause of a `select` statement.
 
-Wherever windows are applied, aggregate functions can be used. In the abvove example, we are calculating
+Wherever windows are applied, aggregate functions can be used. In the above example, we are calculating
 the minimum, maximum, average, standard deviation and variance of a `value` numeric field in data streaming
 into the query via the standard input stream.
 

--- a/docs/tremor-script/functions.md
+++ b/docs/tremor-script/functions.md
@@ -60,7 +60,7 @@ function definition. The anonymous arguments will be provided via the `args` key
 Tail-recursion is provided for fixed arity ( number of arguments ) tandard functions.
 
 Tremor imposes a restriction in recursion depth. As tremor is an event processing system
-it is not desireable to have long running functions that block events from being processed
+it is not desirable to have long running functions that block events from being processed
 through the system.
 
 ```tremor

--- a/docs/tremor-script/index.md
+++ b/docs/tremor-script/index.md
@@ -18,7 +18,7 @@ The language is explicitly not Turing-complete:
 
 ### Developer friendly
 
-The language adopts a fortran-like syntax for key expression forms and has a path-like syntax for indexing into records and arrays
+The language adopts a Fortran-like syntax for key expression forms and has a path-like syntax for indexing into records and arrays
 
 ### Stream-oriented / event-based
 
@@ -809,4 +809,4 @@ The set of supported micro-formats at the time of writing are as follows:
 | **influx**  | Not required                              | Tests if the underlying value conforms to Influx line protocol specification | **record**           | Returns an influx line protocol record matching extractions based on supplied specification |
 | **json**    | Not required                              | Tests if the underlying value is json encoded                                | **depends on value** | Returns a hydrated `tremor-script` value upon extraction                                    |
 
-There is no concept of _injector_ in the `tremor-script` language that is analogous to extractors. Where relevant the langauge supports functions that support the underlying operation ( such as base64 encoding ) and let expressions can be used for assignments.
+There is no concept of _injector_ in the `tremor-script` language that is analogous to extractors. Where relevant the language supports functions that support the underlying operation ( such as base64 encoding ) and let expressions can be used for assignments.

--- a/docs/tremor-script/pp.md
+++ b/docs/tremor-script/pp.md
@@ -29,7 +29,7 @@ The `#!line` directive is a implementation detail mentioned here for the same of
 
 ## Config directive
 
-This directive allows compile-time configuration paraemters to be passed into tremor
+This directive allows compile-time configuration parameters to be passed into tremor
 
 ## Example preprocessed tremor-script
 


### PR DESCRIPTION
Hi there!

I'm trying to know more about Tremor for the GSoC projects and found a few typos in the docs. So I went ahead and did a manual review of the entire docs while I was at it. Let me know if any of these changes is wrong.

Also, not sure why the CI is failing.