### PR TITLE
Fix small yaml typo in mkdocs.yml template.

### DIFF
--- a/mkdocs.yml.in
+++ b/mkdocs.yml.in
@@ -98,7 +98,7 @@ nav:
       - HTTP Load Balancing: workshop/examples/35_reverse_proxy_load_balancing/README.md
       - Quota Service: workshop/examples/36_quota_service/README.md
       - Configurator: workshop/examples/37_configurator/README.md
-    - CNCF
+    - CNCF:
       - OpenTelemetry Passthrough: workshop/examples/40_otel_passthrough/README.md
       - Zipkin Interworking: workshop/examples/41_otel_zipkin/README.md
   - Development:


### PR DESCRIPTION
Signed-off-by: Matthias Wahl <mwahl@wayfair.com>