### PR TITLE
Fix benchmark example name

### DIFF
--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -29,10 +29,10 @@ Where:
 For example:
 
 ```bash
-./bench/run real-workflow-througput-json
+./bench/run real-workflow-throughput-json
 ```
 
-Will run the 'real-workflow-througput-json' benchmark and publish a HDR histogram to standard output
+Will run the 'real-workflow-throughput-json' benchmark and publish a HDR histogram to standard output
 upon completion. it takes about 1 minute to run.
 
 ## Anatomy of a benchmark


### PR DESCRIPTION
Copying and pasting the commands in the document does not make the program work.
This ticket corrects a typo in `real-workflow-througput-json`.

```bash
$ ./bench/run real-workflow-througput-json

++ dirname ./bench/run
+ BENCH_ROOT=./bench
+ . ./bench/common.inc
++ group=tremor-runtime
+++ basename ./bench/run
++ benchmark=run
++ benchmark=run
+++ git rev-parse HEAD
++ hash=bfa5bc0729ad00758a036692bf64cbc35cbe2965
+++ date +%s
++ date=1619926217
+ 'BENCH_EXTRA?='
./bench/run: line 11: BENCH_EXTRA?=: command not found
+ file=real-workflow-througput-json
+ '[' '!' -f real-workflow-througput-json ']'
+ file=./bench/real-workflow-througput-json.yaml
+ '[' '' = devcontainer ']'
+ TARGET_ROOT=target
+ '[' '!' -z ']'
+ '[' '' = debug ']'
+ TARGET_MODE=release
+ '[' '!' -f ./bench/real-workflow-througput-json.yaml ']'
+ echo 'Benchmark file ./bench/real-workflow-througput-json.yaml not found!'
Benchmark file ./bench/real-workflow-througput-json.yaml not found!
+ exit 1
```


## ref:
https://github.com/tremor-rs/tremor-runtime/blob/main/bench/real-workflow-throughput-json.yaml