### PR TITLE
Add current timestamp to logs generated for Quota testing

### DIFF
--- a/docs/workshop/examples/36_quota_service/data/logs_sample
+++ b/docs/workshop/examples/36_quota_service/data/logs_sample
@@ -1,2 +1,2 @@
-{"message":"test log message","application":"test-app","logger_name":"test-logger","@timestamp":"2020-10-06T21:11:05.827Z","hostname":"test-host","log_level":"INFO"}
-{"message":"hello world","application":"tremolo","logger_name":"snot","@timestamp":"2020-10-06T22:11:05.827Z","hostname":"snot-factory","log_level":"TRACE"}
+{"message":"test log message","application":"test-app","logger_name":"test-logger","@timestamp":"%TIMESTAMP%","hostname":"test-host","log_level":"INFO"}
+{"message":"hello world","application":"tremolo","logger_name":"snot","@timestamp":"%TIMESTAMP%","hostname":"snot-factory","log_level":"TRACE"}

--- a/docs/workshop/examples/36_quota_service/logger.sh
+++ b/docs/workshop/examples/36_quota_service/logger.sh
@@ -8,7 +8,8 @@ LOG_INTERVAL=0.01 # in seconds
 while true; do
   while read log_line; do
     [ -z "$log_line" ] && continue # skip empty lines
-    echo "$log_line"
+    TS=`date -u +"%Y-%m-%dT%H:%M:%S"`
+    echo "$log_line" | sed "s/%TIMESTAMP%/$TS/"
     #echo "Sleeping for ${LOG_INTERVAL}s..." >&2
     sleep "$LOG_INTERVAL"
   done < "$INPUT_FILE"


### PR DESCRIPTION
Generate dynamic timestamp for each log message, so that the change in volume can be visible after quota change thru api.
![image](https://user-images.githubusercontent.com/3475422/117104943-07cd9c80-ad4b-11eb-9891-3ff71fb126d3.png)
