### PR TITLE
fixed config example for gcloud connectors

### DIFF
--- a/docs/artefacts/offramps.md
+++ b/docs/artefacts/offramps.md
@@ -486,9 +486,11 @@ offramp:
     codec: json
     linked: true
     postprocessors:
-      - gzip
+      - lines 
+      - gzip   
     preprocessors:
-      - gzip
+      - gzip 
+      - lines
 ```
 
 If the use case for the offramp requires metadata from the Google Cloud Storage service on the supported operations for this offramp, then set linked to true and configure the output port `out`.
@@ -867,6 +869,7 @@ offramp:
     type: gpub
     codec: json
     postprocessors:
+      - lines
       - gzip    
     linked: true
     config:

--- a/docs/artefacts/onramps.md
+++ b/docs/artefacts/onramps.md
@@ -370,6 +370,7 @@ onramp:
     codec: json
     preprocessors:
       - gzip
+      - lines
     config:
       pem: gcp.pem
       subscription: "tremor-sub"


### PR DESCRIPTION
Signed-off-by: Jigyasa <jigyasakhaneja05@gmail.com>
 
Added lines preprocessor and postprocessor in the config examples of gcs, gpub, gsub. Since for stream-based connectors, we require preprocessor and postprocessor as the source doesn't know where or when a packet ends.