### PR TITLE
fixing gcloud connectors example

### DIFF
--- a/docs/artefacts/offramps.md
+++ b/docs/artefacts/offramps.md
@@ -486,11 +486,9 @@ offramp:
     codec: json
     linked: true
     postprocessors:
-      - lines 
       - gzip   
     preprocessors:
       - gzip 
-      - lines
 ```
 
 If the use case for the offramp requires metadata from the Google Cloud Storage service on the supported operations for this offramp, then set linked to true and configure the output port `out`.
@@ -869,7 +867,6 @@ offramp:
     type: gpub
     codec: json
     postprocessors:
-      - lines
       - gzip    
     linked: true
     config:

--- a/docs/artefacts/onramps.md
+++ b/docs/artefacts/onramps.md
@@ -370,7 +370,6 @@ onramp:
     codec: json
     preprocessors:
       - gzip
-      - lines
     config:
       pem: gcp.pem
       subscription: "tremor-sub"


### PR DESCRIPTION
Signed-off-by: Jigyasa <jigyasakhaneja05@gmail.com>
I misunderstood gcloud sources and sinks as stream based and had added the `lines` preprocessor and postprocessor in the examples. Fixed it to what it was before. Sorry!! ;-;